### PR TITLE
Change test for existence of stats

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -265,7 +265,7 @@ sub get_compara_alignments {
   my $data = {};
   my $species = {};
 # existence of this tag defines if stats are available
-  my $stats_tag = 'num_blocks';
+  my $stats_tag = 'ref_genome_length';
   
   ## Munge all the necessary information
   foreach my $method (@{$methods||[]}) {


### PR DESCRIPTION
The old tag used to determine if stats existed wasn't appropriate for synteny; changed to one that'll work for alignments and synteny.