### PR TITLE
Update Literature.pm

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/Literature.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Literature.pm
@@ -32,7 +32,7 @@ sub content {
   my $object       = $self->object;
   my $html;
   
-  my $query = sprintf '"%s"', join('" OR "', @{$self->get_gene_names});
+  my $query = sprintf 'FULL_EXACT:"%s"', join('" OR FULL_EXACT:"', @{$self->get_gene_names});
   my ($articles, $error) = $self->europe_pmc_articles($query);
 
   if ($error) {


### PR DESCRIPTION
gets rid of 90% of the cruft by turning off the stemmer on the gene names.