### PR TITLE
fix(ViewConfig): Change label from "Selected individuals" to "Selected samples"

### DIFF
--- a/modules/EnsEMBL/Web/ViewConfig/Transcript/PopulationImage.pm
+++ b/modules/EnsEMBL/Web/ViewConfig/Transcript/PopulationImage.pm
@@ -39,7 +39,7 @@ sub form {
   my %type       = %{$options{'type'}};
 
   # Add Individual selection
-  $self->add_fieldset('Selected individuals');
+  $self->add_fieldset('Selected samples');
 
   my @strains = (@{$variations->{'DEFAULT_STRAINS'}}, @{$variations->{'DISPLAY_STRAINS'}});
 


### PR DESCRIPTION
This change should fix ENSEMBL-4436: Label reading "Selected individuals" should read "Selected samples" on the "Configure this page" popup on the Comparison image.