### PR TITLE
ENSEMBL-5153 biomart dataset name prefix is the last species part

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/Go.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Go.pm
@@ -82,7 +82,7 @@ sub biomart_link {
 
   my $vschema        = sprintf '%s_mart', $self->hub->species_defs->GENOMIC_UNIT;
   my (@species)      = split /_/, $self->object->species;
-  my $attr_prefix    = lc(substr($species[0], 0, 1) . $species[1] . "_eg_gene");
+  my $attr_prefix    = lc(substr($species[0], 0, 1) . $species[-1] . "_eg_gene");
   my ($ontology)     = split /:/, $term;
   my $biomart_filter = EnsEMBL::Web::Constants::ONTOLOGY_SETTINGS->{$ontology}->{biomart_filter};
 


### PR DESCRIPTION
e.g. Aedes_aegypti_lvpagwg will give alvpagwg, not aaegypti