### PR TITLE
Update date for release 38

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -27,7 +27,7 @@ sub update_conf {
   $SiteDefs::ENSEMBL_COHORT = 'EnsemblGenomes';
   
   $SiteDefs::SITE_RELEASE_VERSION = 38;
-  $SiteDefs::SITE_RELEASE_DATE    = 'December 2017';
+  $SiteDefs::SITE_RELEASE_DATE    = 'January 2018';
   $SiteDefs::SITE_MISSION         = 'Ensembl Genomes provides integrated access to genome-scale data from invertebrate metazoa, plants, fungi, protists and bacteria in partnership with the scientifc communities that work in each domain.';
     
   @SiteDefs::ENSEMBL_PERL_DIRS    = (


### PR DESCRIPTION
Footer of EG sites should display "January 2018" instead of "December 2017"