### PR TITLE
Update KEGG_Enzyme url

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -93,9 +93,6 @@ sub _sort_similarity_links {
       $word .= " ($primary_id)" if $A eq 'MARKERSYMBOL';
 
       if ($link) {
-## EG - VectorBase hack for KEGG Enzyme acc which contains both pathway and enzyme id
-        $link =~ s/%2B/&multi_query=/ if $externalDB eq 'KEGG_Enzyme';
-##
         $text = qq{<a href="$link" class="constant">$word</a>};
       } else {
         $text = $word;


### PR DESCRIPTION
## Description
Biomart uses the data in the defaults.ini file to construct links for output page. But it doesn't do the post-processing in the Shared.pm file, so the biomart urls are broken. We can tweak the url template such that it works without modification, so it works for biomart and means we can eliminate the special treatment in the webcode.

## Views affected
URLs for KEGG_Enzyme xrefs on "General Identifiers" page will be different, but will resolve to the same external page as they currently do.

## Possible complications/merge conflicts
Not aware of any.

Note that the same change has been requested in the ensembl-webcode repo: https://github.com/Ensembl/ensembl-webcode/pull/680