### PR TITLE
Fix gene families link for non-vertebrates sites

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -54,6 +54,8 @@ sub update_conf {
   # disable sprite maps - not used for EG
   $SiteDefs::ENSEMBL_DEBUG_IMAGES = 1;
   
+  $SiteDefs::GENE_FAMILY_ACTION = 'Gene_families'; # Used to build the link to gene families page
+
   #---------------------------------------------------------------------------- 
   # TOOLS
   #----------------------------------------------------------------------------


### PR DESCRIPTION
Related to [this PR](https://github.com/Ensembl/ensembl-webcode/pull/713) in ensembl-webcode. Briefly, this PR introduces a variable into SiteDefs, which is then used to generate a link to gene families page shown in the "About this gene" section on the gene page.

Should produce a link of shape `/:species/Gene/Gene_families` (as opposed to `/:species/Gene/Family` on the www site.

Examples of broken link (to "Ensembl protein families"):
- for protists: http://protists.ensembl.org/Pythium_vexans/Gene/Gene_families?db=core;g=maker-pve_contig_1376-snap-gene-0.1;r=pve_scaffold_1376:241-942;t=EPrPVT00000023679
- for fungi: https://fungi.ensembl.org/Magnaporthe_oryzae/Gene/Summary?db=core;g=MGG_01236;r=2:2789925-2792654;t=MGG_01236T0
(no examples for plants, metazoa, or bacteria)