### PR TITLE
Add SiteDefs variable to hide 'Download family alignment' button

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -55,6 +55,7 @@ sub update_conf {
   $SiteDefs::ENSEMBL_DEBUG_IMAGES = 1;
   
   $SiteDefs::GENE_FAMILY_ACTION = 'Gene_families'; # Used to build the link to gene families page
+  $SiteDefs::FAMILY_ALIGNMENTS_DOWNLOADABLE   = 0; # Sequence alignments are not available for non-vertebrates
 
   #---------------------------------------------------------------------------- 
   # TOOLS


### PR DESCRIPTION
## Description
Adding a SiteDefs variable to hide the "Download family alignment" button.

Depends on PR https://github.com/Ensembl/ensembl-webcode/pull/726 in ensembl-webcode

## Related JIRA Issues (EBI developers only)
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5255