### PR TITLE
ENSWEB-4544: fix genetree inconsistencies

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree.pm
@@ -167,15 +167,19 @@ sub _init {
     }
 
     # Node glyph, coloured for for duplication/speciation
-    my ($node_colour, $label_colour, $collapsed_colour, $bold);
+    my ($node_colour, $label_colour, $collapsed_colour);
+    my $bold = 0;
     
-    if ($f->{_node_type} eq 'duplication') {
-      $node_colour = 'red3';
-    } elsif ($f->{_node_type} eq 'dubious') {
-      $node_colour = 'turquoise';
-    } elsif ($f->{_node_type} eq 'gene_split') {
-      $node_colour = 'SandyBrown';
-    } 
+    if (defined $f->{_node_type}) {
+      if ($f->{_node_type} eq 'duplication') {
+        $node_colour = 'red3';
+      } elsif ($f->{_node_type} eq 'dubious') {
+        $node_colour = 'turquoise';
+      } elsif ($f->{_node_type} eq 'gene_split') {
+        $node_colour = 'SandyBrown';
+      }
+    }
+
     #node colour categorisation for cafetree/speciestree/gainloss tree
     if($tree->isa('Bio::EnsEMBL::Compara::CAFEGeneFamilyNode')) {      
       $border_colour = 'black';
@@ -185,16 +189,15 @@ sub _init {
       $node_colour = '#FE9929' if($f->{_n_members} >= 11 && $f->{_n_members} <= 15);
       $node_colour = '#EC7014' if($f->{_n_members} >= 16 && $f->{_n_members} <= 20);
       $node_colour = '#CC4C02' if($f->{_n_members} >= 21 && $f->{_n_members} <= 25);
-      $node_colour = '#8C2D04' if($f->{_n_members} >= 25);     
-      
+      $node_colour = '#8C2D04' if($f->{_n_members} >= 25);
     }
 
-    if ($f->{label} && $f->{label} !~ m/homologs/) {
-      if( $f->{_genes}->{$other_gene} ){
+    if ( $f->{label} ) {
+      if( $other_gene && $f->{_genes}->{$other_gene} ){
         $bold = 1;
         $label_colour = "ff6666";
-      } elsif( $f->{_genome_dbs}->{$other_genome_db_id} ){
-        $bold = 1 if $highlight_gene;
+      } elsif( $other_genome_db_id && $f->{_genome_dbs}->{$other_genome_db_id} ){
+        $bold = 1;
       } elsif( $f->{_genes}->{$current_gene} ){
         $label_colour     = 'red';
         $collapsed_colour = 'red';
@@ -202,7 +205,7 @@ sub _init {
         $bold = defined($other_genome_db_id);
       } elsif( $f->{_genome_dbs}->{$current_genome_db_id} ){
         $label_colour     = 'blue';
-        $collapsed_colour = 'navyblue';
+        $collapsed_colour = 'blue';
         $bold = defined($other_genome_db_id);
       }
     }


### PR DESCRIPTION
This PR fixes the gene tree inconsistencies highlighted in [ENSWEB-4544](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-4544). Link to the sandbox is:
http://ves-hx-78.ebi.ac.uk:9310/Physcomitrella_patens/Gene/Compara_Tree?g=Pp3c2_11370;r=2:7569830-7572269