### PR TITLE
Handle change in meta keys for assembly and annotation providers

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
+++ b/modules/Bio/EnsEMBL/Utils/SeqDumper.pm
@@ -142,7 +142,7 @@ sub dump_embl {
 
   #Description
 ## EG : 
-  my $providers  =  join ' ,',  @{ $meta_container->list_value_by_key('provider.name') };
+  my $providers  =  join ' ,',  @{ $meta_container->list_value_by_key('annotation.provider_name') };
   
   $self->write($FH, $EMBL_HEADER, 'DE', $meta_container->get_scientific_name() .
                " $name_str $start..$end " . ($providers ? "annotated by $providers" : ''));

--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -145,8 +145,8 @@ sub content {
   my $img_url      = $self->img_url;
   my $provider_link = '';
 
-  if ($species_defs->PROVIDER_NAME) {
-    my ($name, $url) = ($species_defs->PROVIDER_NAME, $species_defs->PROVIDER_URL);
+  if ($species_defs->ASSEMBLY_PROVIDER_NAME) {
+    my ($name, $url) = ($species_defs->ASSEMBLY_PROVIDER_NAME, $species_defs->ASSEMBLY_PROVIDER_URL);
     $name = [$name] unless ref $name eq 'ARRAY';
     $url  = [$url]  unless ref $url  eq 'ARRAY';
     my @providers = map { $hub->make_link_tag(text => $name->[$_], url => $url->[$_]) } 0 .. scalar @{$name} - 1;

--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -641,7 +641,7 @@ sub species_stats {
   });
   $summary->add_row({
       'name' => '<b>Genebuild by</b>',
-      'stat' => $sd->GENEBUILD_BY
+      'stat' => $sd->ANNOTATION_PROVIDER_NAME
   });
   my @A         = @{$meta_container->list_value_by_key('genebuild.method')};
   my $method  = ucfirst($A[0]) || '';
@@ -675,9 +675,9 @@ sub species_stats {
   
   # data source
 
-  if (my $names = $sd->PROVIDER_NAME) {
+  if (my $names = $sd->ASSEMBLY_PROVIDER_NAME) {
     
-    my $urls = $sd->PROVIDER_URL;
+    my $urls = $sd->ASSEMBLY_PROVIDER_URL;
 
     $names = [$names] if ref $names ne 'ARRAY';
     $urls  = [$urls]  if ref $urls  ne 'ARRAY';

--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -313,9 +313,10 @@ sub _munge_meta {
     liftover.mapping              ASSEMBLY_MAPPINGS
     genebuild.method              GENEBUILD_METHOD
     genebuild.version             GENEBUILD_VERSION
-    provider.name                 PROVIDER_NAME
-    provider.url                  PROVIDER_URL
-    provider.logo                 PROVIDER_LOGO
+    assembly.provider_name        ASSEMBLY_PROVIDER_NAME
+    assembly.provider_url         ASSEMBLY_PROVIDER_URL
+    annotation.provider_name      ANNOTATION_PROVIDER_NAME
+    annotation.provider_url       ANNOTATION_PROVIDER_URL
     species.strain                SPECIES_STRAIN
     species.strain_group          STRAIN_GROUP
     strain.type                   STRAIN_TYPE
@@ -428,7 +429,6 @@ sub _munge_meta {
     my @A = split '-', $meta_hash->{'genebuild.start_date'}[0];
     
     $self->tree($production_name)->{'GENEBUILD_START'} = $A[1] ? "$months[$A[1]] $A[0]" : undef;
-    $self->tree($production_name)->{'GENEBUILD_BY'}    = $A[2];
 
     @A = split '-', $meta_hash->{'genebuild.initial_release_date'}[0];
     


### PR DESCRIPTION
Part of the code changes required for https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5415

See full description in https://github.com/Ensembl/ensembl-webcode/pull/778

Sandbox for plants with applied changes: http://ves-hx2-76.ebi.ac.uk:8450/Arabidopsis_thaliana/Info/Annotation

Also, the page with exported gene (notice the correct name next to the "annotated by"): http://ves-hx2-76.ebi.ac.uk:8450/Arabidopsis_thaliana/Export/Output/Gene?db=core;flank3_display=0;flank5_display=0;g=AT3G52430;output=embl;r=3:19431095-19434450;strand=feature;t=AT3G52430.1;param=similarity;param=repeat;param=genscan;param=contig;param=variation;param=marker;param=gene;param=vegagene;param=estgene;_format=Text