### PR TITLE
Use display name for labels in the taxon tree

### DIFF
--- a/utils/dump_taxon_tree.pl
+++ b/utils/dump_taxon_tree.pl
@@ -265,13 +265,11 @@ sub node_to_dynatree {
   
   if (@{$node->dba}) {
     foreach my $dba (@{$node->dba}) {
-      my $gca;
-      if ($dba->species =~ /gca_(\d+)/) {
-      	$gca = " (GCA_$1)";
-      }
+      my $meta_adaptor = Bio::EnsEMBL::Registry->get_adaptor( $dba->species, "core", "MetaContainer" );
+      my $display_name = $meta_adaptor->get_display_name();
       push @output, {  
         key   => ucfirst($dba->species),
-        title => $name . $gca 
+        title => $display_name
       };
     }
   }  

--- a/utils/dump_taxon_tree.pl
+++ b/utils/dump_taxon_tree.pl
@@ -265,8 +265,7 @@ sub node_to_dynatree {
   
   if (@{$node->dba}) {
     foreach my $dba (@{$node->dba}) {
-      my $meta_adaptor = Bio::EnsEMBL::Registry->get_adaptor( $dba->species, "core", "MetaContainer" );
-      my $display_name = $meta_adaptor->get_display_name();
+      my $display_name = get_node_display_name($dba, $name);
       push @output, {  
         key   => ucfirst($dba->species),
         title => $display_name
@@ -275,6 +274,22 @@ sub node_to_dynatree {
   }  
   
   return @output;
+}
+
+sub get_node_display_name {
+  # this subroutine should not be necessary; we expect each node to have core adaptors, including the MetaContainer,
+  # but at the same time, we are a bit nervous to trust the Perl API entirely
+  my ($node_dba, $fallback_name) = @_;
+  my $meta_adaptor = Bio::EnsEMBL::Registry->get_adaptor( $node_dba->species, "core", "MetaContainer" );
+  if ($meta_adaptor) {
+    return $meta_adaptor->get_display_name();
+  } else {
+    if ($node_dba->species =~ /gca_(\d+)/) {
+      return $fallback_name . " (GCA_$1)";
+    } else {
+      return $fallback_name;
+    }
+  }
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The script that is dumping the taxon tree is using scientific names of the species. This results in the same indistinguishable labels for different strains of the same species:

<img src="https://user-images.githubusercontent.com/6834224/92138347-29663500-ee06-11ea-9867-9c2743dc6a95.png" width=300 />

## Solution
It was decided that we use species display name for the label.

### Note
Using `species.display_name` value makes the [previous change](https://www.ebi.ac.uk/panda/jira/browse/ENSEMBL-5176) for displaying the GCA values next to bacteria names redundant. The GCA values are already included in bacteria display names, as can be seen from the database:

```
MySQL [bacteria_123_collection_core_48_101_1]> select ref.meta_value as production_name, m.meta_value as display_name from meta as m join meta as ref on m.species_id = ref.species_id where m.meta_key = "species.display_name" and ref.meta_key like "species.production_name" limit 20;
+--------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
| production_name                                                                | display_name                                                                       |
+--------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
| streptococcus_pneumoniae_gca_001106185                                         | Streptococcus pneumoniae (GCA_001106185)                                           |
| streptococcus_pneumoniae_gca_001149045                                         | Streptococcus pneumoniae (GCA_001149045)                                           |
| streptococcus_pneumoniae_gca_001110525                                         | Streptococcus pneumoniae (GCA_001110525)                                           |
| pseudomonas_aeruginosa_gca_001181745                                           | Pseudomonas aeruginosa (GCA_001181745)                                             |
| anaplasma_phagocytophilum_str_apnyw                                            | Anaplasma phagocytophilum str. ApNYW                                               |
| klebsiella_pneumoniae_gca_001031075                                            | Klebsiella pneumoniae (GCA_001031075)                                              |
| neisseria_meningitidis_gca_001085765                                           | Neisseria meningitidis (GCA_001085765)                                             |
| salmonella_enterica_subsp_enterica_serovar_typhi_gca_001106045                 | Salmonella enterica subsp. enterica serovar Typhi (GCA_001106045)                  |
| devosia_limi_dsm_17137                                                         | Devosia limi DSM 17137                                                             |
| pseudomonas_aeruginosa_gca_001180705                                           | Pseudomonas aeruginosa (GCA_001180705)                                             |
| proteus_vulgaris_gca_001049955                                                 | Proteus vulgaris (GCA_001049955)                                                   |
| orientia_tsutsugamushi_str_sido                                                | Orientia tsutsugamushi str. Sido                                                   |
| acinetobacter_baumannii_gca_000810205                                          | Acinetobacter baumannii (GCA_000810205)                                            |
| candidatus_collierbacteria_bacterium_gw2011_gwa2_46_26                         | Candidatus Collierbacteria bacterium GW2011_GWA2_46_26                             |
| candidatus_giovannonibacteria_bacterium_gw2011_gwc2_44_9                       | Candidatus Giovannonibacteria bacterium GW2011_GWC2_44_9                           |
| salmonella_enterica_subsp_enterica_serovar_typhimurium_str_dt104_gca_001218545 | Salmonella enterica subsp. enterica serovar Typhimurium str. DT104 (GCA_001218545) |
| streptococcus_uberis_6736                                                      | Streptococcus uberis 6736                                                          |
| streptococcus_pneumoniae_gca_001212105                                         | Streptococcus pneumoniae (GCA_001212105)                                           |
| staphylococcus_aureus_gca_001198135                                            | Staphylococcus aureus (GCA_001198135)                                              |
| vibrio_cholerae_gca_001254915                                                  | Vibrio cholerae (GCA_001254915)                                                    |
+--------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
20 rows in set (0.00 sec)

```

## Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-5948

## Sandbox
http://ves-hx2-76.ebi.ac.uk:8450/Oryza_sativa/Tools/Blast