### PR TITLE
added cshl_noncoding_gene_misc_non_coding 

### DIFF
--- a/conf/ini-files/COLOUR.ini
+++ b/conf/ini-files/COLOUR.ini
@@ -133,7 +133,7 @@ cufflinks_3b_nontranslating_cds          = #FF6EC7                3B non transla
 
 gff3_lc_genes_protein_coding             = red;section:pc         Alternative genes
 
-
+cshl_noncoding_gene_misc_non_coding      = darkorange;section:npc     CSHL noncoding gene
 
 
 ## /EG Plants


### PR DESCRIPTION
Hi, during testing of https://staging-plants.ensembl.org/Zea_mays/Gene/Summary?g=Zm00001eb113450;r=2:230473563-230476257;t=Zm00001eb113450_T001 @ens-st3 discovered that genes of analysis 'cshl_noncoding_gene' and biotype 'misc_non_coding' lacked a color. This PR adds it
