### PR TITLE
added cshl_gene_protein_coding

### DIFF
--- a/conf/ini-files/COLOUR.ini
+++ b/conf/ini-files/COLOUR.ini
@@ -133,6 +133,7 @@ cufflinks_3b_nontranslating_cds          = #FF6EC7                3B non transla
 
 gff3_lc_genes_protein_coding             = red;section:pc         Alternative genes
 
+cshl_gene_protein_coding                 = red;section:pc             CSHL protein coding gene
 cshl_noncoding_gene_misc_non_coding      = darkorange;section:npc     CSHL noncoding gene
 
 


### PR DESCRIPTION
This PR follows from https://github.com/EnsemblGenomes/eg-web-common/pull/77

The protein-coding gene at  https://staging-plants.ensembl.org/Zea_mays/Gene/Summary?g=Zm00001eb113450;r=2:230473563-230476257;t=Zm00001eb113450_T001 is not properly colored nor labelled. This PR should fix it