### PR TITLE
Fix the pan-compara image export issue

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -32,7 +32,7 @@ sub content {
   my ($gene, $member, $tree, $node, $test_tree);
 
   my $type   = $self->param('data_type') || $hub->type;
-  my $vc = $self->view_config($type);
+  my $vc = $self->viewconfig($type);
 
 ## EG  
   my $url_function = $hub->function;


### PR DESCRIPTION
Description:
- Fixed the error that occurs when we try to export pan-compara tree image

Views Affected:
- I have tested this fix on the staging site

Related JIRA:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6323