### PR TITLE
Update ENA link for assemblies

### DIFF
--- a/modules/EnsEMBL/Web/Component/Shared.pm
+++ b/modules/EnsEMBL/Web/Component/Shared.pm
@@ -618,7 +618,7 @@ sub species_stats {
       $a_id .= " ($long)";
     }
     if (my ($acc) = @{$meta_container->list_value_by_key('assembly.accession')}) {
-      $acc = sprintf('INSDC Assembly <a href="http://www.ebi.ac.uk/ena/data/view/%s">%s</a>', $acc, $acc);
+      $acc = sprintf('INSDC Assembly <a href="https://www.ebi.ac.uk/ena/browser/view/%s">%s</a>', $acc, $acc);
       $a_id .= ", $acc";
     }
   }


### PR DESCRIPTION
## Description

Bruno notified us that links to ENA pages for assemblies have been updated from `http://www.ebi.ac.uk/ena/data/view/:assembly_accession_id` to `https://www.ebi.ac.uk/ena/browser/view/:assembly_accession_id`.

Links to assemblies aren't saved in the database, but are generated on the fly according to a template stored in the `Shared.pm` file. This PR updates the template.

## Link to Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6342

## Sandbox url
http://ves-hx2-75.ebi.ac.uk:8450/Arabidopsis_thaliana/Info/Annotation/#genebuild