### PR TITLE
Add option to limit maximum HSPs

### DIFF
--- a/modules/EnsEMBL/Web/BlastConstants.pm
+++ b/modules/EnsEMBL/Web/BlastConstants.pm
@@ -46,9 +46,13 @@ sub CONFIGURATION_FIELDS {
         'type'                => 'dropdown',
         'label'               => 'E-value threshold',
         'values'              => [ map { 'value' => $_, 'caption' => $_ }, qw(1e-200 1e-100 1e-50 1e-10 1e-5 1e-4 1e-3 1e-2 1e-1 1.0 10 100 1000 10000) ]
-      }
-      ]
-
+      },
+      'hsps'                => {
+        'type'                => 'dropdown',
+        'label'               => 'Maximum HSPs per hit',
+        'value'               => '100',
+        'values'              => [ map { 'value' => $_, 'caption' => $_ }, qw(1 2 5 10 50 100) ]
+      }]
     },
 
     'scoring'             => {
@@ -107,6 +111,7 @@ sub CONFIGURATION_FIELDS {
       'caption'             => '',
       'fields'              => [
 
+
       'filter'              => {
         'type'                => 'checklist',
         'label'               => 'Filter low complexity regions',
@@ -135,6 +140,7 @@ sub CONFIGURATION_DEFAULTS {
       'gapopen'                 => '5',
       'gapext'                  => '2',
       'gapalign'                => '1',      
+      'hsps'                    => '100'
     },
 
     'NCBIBLAST_BLASTP'        => {
@@ -143,6 +149,7 @@ sub CONFIGURATION_DEFAULTS {
       'gapopen'                 => '11',
       'gapext'                  => '1',
       'gapalign'                => '1',      
+      'hsps'                    => '100'
     },
 
     'NCBIBLAST_BLASTX'        => {
@@ -151,10 +158,12 @@ sub CONFIGURATION_DEFAULTS {
       'gapopen'                 => '11',
       'gapext'                  => '1',
       'gapalign'                => '1',            
+      'hsps'                    => '100'
     },
 
     'NCBIBLAST_TBLASTX'       => {
       'matrix'                  => 'BLOSUM62',
+      'hsps'                    => '100'
     },
 
     'NCBIBLAST_TBLASTN'       => {
@@ -164,6 +173,7 @@ sub CONFIGURATION_DEFAULTS {
       'gapext'                  => '1',
       'gapalign'                => '1',   
       'compstats'               => 'F',
+      'hsps'                    => '100'
     },
 
   };


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6207

As for now, when using EBI Blast tool (wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/run)
only max_target_seqs is limited by using `&alignments=` (may be `&scores=`) parameter(s).
Sometimes there could be multiple hits (HSPs) on the same target sequence (i.e. we can have long targets, query with repeats). We need to be able to pass a freshly added parameter `hsps=` (controlling BLAST's `-max_hsps` option): https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=94147939#NCBIBLAST+HelpandDocumentation-hsps

If not, we can have 400k hits instead of ~50-2500 (depending on your understanding of semantics behind `Maximum number of alignments displayed` and `Maximum number of scores displayed`).

EBI blast uses `hsps` as param  which internally converts into NCBI blast format `max-hsps` 

Failed job that was reported via RT works on my sandbox.
http://wp-np2-1e.ebi.ac.uk:9002/Multi/Tools/Blast/View?db=core;tl=8BOMd4mczM8a7d3A-617