### PR TITLE
Fix metadata file links

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -80,6 +80,7 @@ sub metadata {
   my $self = shift;
   my $sd = $self->hub->species_defs;
 
+  my $ftp = $sd->ENSEMBL_GENOMES_FTP_URL;
   my $division = $sd->EG_DIVISION;
   my $uc_div   = ucfirst($division);
 


### PR DESCRIPTION
Fixes broken FTP links in the metadata files section.

JIRA ticket: [ENSWEB-6376](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6376)