### PR TITLE
Feature/validate idmapper

### DIFF
--- a/modules/EnsEMBL/Web/Controller/Ajax.pm
+++ b/modules/EnsEMBL/Web/Controller/Ajax.pm
@@ -34,7 +34,17 @@ sub ajax_species_autocomplete {
   my $term          = $hub->param('term'); # will return everything if no term specified
   my $result_format = $hub->param('result_format') || 'simple'; # simple/chosen
   
-  my @species = $species_defs->valid_species;
+  ## For ID history mapper, filter out species with no data
+  my @species;
+  if ($hub->action eq 'IDMapper') {
+    foreach ($species_defs->valid_species) {
+      my $history = $species_defs->table_info_other($_, 'core', 'stable_id_event');
+      push @species, $_ if $history->{'rows'};
+    } 
+  }
+  else {
+    @species = $species_defs->valid_species;
+  }
   
   # sub to normalise strings for comparison e.g. k-12 == k12
   my $normalise = sub { 

--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -152,8 +152,10 @@ sub add_alignments {
   my ($self, $key, $hashref, $species) = @_;
 
   return unless grep $self->get_node($_), qw(multiple_align pairwise_tblat pairwise_blastz pairwise_other conservation);
-
+  
   my $species_defs = $self->species_defs;
+  ## Convert to production name, as that's what we now prefer
+  $species         = $species_defs->get_config($species, 'SPECIES_PRODUCTION_NAME');
 
   return if $species_defs->ENSEMBL_SUBTYPE eq 'Pre';
 


### PR DESCRIPTION
As reported in this ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6242

Some bacteria lack ID mapping, which results in the user submitted jobs that inevitably fail, with a cryptic error message. As suggested by Ridwan in my previous PR (below), the most straightforward solution is to filter out species that don't have the data, but I haven't been able to test it in a sandbox yet. It shouldn't affect anything except the ID History Mapper.

https://github.com/Ensembl/public-plugins/pull/486

I suggest that if it looks sensible, we merge it in and try it out on the test sites when they go up. We should ensure that you cannot select the bacterial species mentioned in the JIRA ticket, and also check it does not break either www or another NV site such as plants.