### PR TITLE
Use https for the rest url

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -37,7 +37,7 @@ ENSEMBL_TEXT_INDEXER = EBeye
 ENSEMBL_DEFAULT_SEARCHCODE    = ensemblunit
 TEMPLATE_ROOT = /eg-plugins/common/templates
 
-ENSEMBL_REST_URL              = http://rest.ensembl.org
+ENSEMBL_REST_URL              = https://rest.ensembl.org
 
 ; Blog details, for accessing news feed
 ENSEMBL_BLOG_URL          = http://www.ensembl.info


### PR DESCRIPTION
**Problem:** alphafold widget doesn't show up on the plants site (e.g. [link](https://plants.ensembl.org/Arabidopsis_thaliana/Transcript/AFDB?db=core;g=AT3G52430;r=3:19431095-19434450;t=AT3G52430.1)).

**Cause of the problem:** the url for the rest api that comes from the server has `http` in its protocol, while the plants site runs on https.

![image](https://user-images.githubusercontent.com/6834224/145651099-89f82164-2d07-4ddb-a1b7-ef7bee427270.png)

As a result, the browser blocks the mixed-content request:

![image](https://user-images.githubusercontent.com/6834224/145650889-bba2af52-6ea5-4123-b6af-76cd98b6df6a.png)

I am not sure this is exactly the place that sets this variable, but it seems to be the most likely. Even if it weren't the right place, we should use https over http.