### PR TITLE
Fix for missing orthologues

### DIFF
--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -294,7 +294,9 @@ sub fetch_homology_species_hash {
       }      
     }
 
-    push @{$homologues{$name_lookup->{$genome_db_name}}}, [ $target_member, $homology->description, $homology->species_tree_node(), $query_perc_id, $target_perc_id, $dnds_ratio, $homology->{_gene_tree_node_id}, $homology->dbID, $goc_score, $goc_threshold, $wgac, $wga_threshold, $highconfidence ];    
+    my $species_url = $name_lookup->{$genome_db_name} || $genome_db_name;
+
+    push @{$homologues{$species_url}}, [ $target_member, $homology->description, $homology->species_tree_node(), $query_perc_id, $target_perc_id, $dnds_ratio, $homology->{_gene_tree_node_id}, $homology->dbID, $goc_score, $goc_threshold, $wgac, $wga_threshold, $highconfidence ];    
   }
 
   @{$homologues{$_}} = sort { $classification->{$a->[2]} <=> $classification->{$b->[2]} } @{$homologues{$_}} for keys %homologues;  


### PR DESCRIPTION
Related JIRA:
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6496

Sandbox URL:
http://wp-np2-1d.ebi.ac.uk:42228/Arabidopsis_thaliana/Gene/Compara_Ortholog?db=core;g=AT4G30560;r=4:14926834-14930355;t=AT4G30560.1

**NOTE:** Once this gets merged, I will cherry-pick the changes on to 105