### PR TITLE
Update ftp links to https

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -694,7 +694,7 @@ METAZOA = http://metazoa.ensembl.org/###SPECIES###
 FUNGI = http://fungi.ensembl.org/###SPECIES###
 VECTORBASE = https://www.vectorbase.org/###SPECIES###
 
-SPECIES_FTP_URL = http://ftp.ensemblgenomes.org/pub/###GENOMIC_UNIT###/release-###VERSION###/###FORMAT###/###SPECIES###
+SPECIES_FTP_URL = https://ftp.ensemblgenomes.org/pub/###GENOMIC_UNIT###/release-###VERSION###/###FORMAT###/###SPECIES###
 BACTERIA = http://bacteria.ensembl.org/###SPECIES###
 BACTERIA_BACILLUS = http://bacteria.ensembl.org/Bacillus/###SPECIES###
 BACTERIA_BORRELIA = http://bacteria.ensembl.org/Borrelia/###SPECIES###

--- a/htdocs/info/data/mysql.html
+++ b/htdocs/info/data/mysql.html
@@ -52,11 +52,11 @@ can be used in conjuction with the <a href="http://www.ensembl.org/info/data/mys
 
 <p>The MySQL server is provided 'as-is', though scheduled downtime will be publicised on the mailing lists and on the <a href="https://www.ensembl.info">Ensembl blog</a>. Please note that processes that use this service excessively to the detriment of other users may be terminated without warning to preserve the service functionality. For intensive use of this server, an alternative is to set up a local MySQL database with <a href="info/data/ftp/">copies of Ensembl Genomes data</a>.</p>
 
-<p>The public MySQL server is restricted to data from the most recent 10 releases only. With each subsequent release, data from the oldest release will be removed at release time. The removal of each release will be announced with the intentions for the new release approximately 2 months in advance. MySQL dumps from all previous releases are always available from the <a href="http://ftp.ensemblgenomes.org/pub/current">Ensembl Genomes FTP site</a>.</p>
+<p>The public MySQL server is restricted to data from the most recent 10 releases only. With each subsequent release, data from the oldest release will be removed at release time. The removal of each release will be announced with the intentions for the new release approximately 2 months in advance. MySQL dumps from all previous releases are always available from the <a href="https://ftp.ensemblgenomes.org/pub/current">Ensembl Genomes FTP site</a>.</p>
 
 <h2>Installing local MySQL databases</h2>
 
-<p>When creating a Ensembl Genomes mirror, or to use local MySQL databases with the Ensembl Perl API, dumps  of MySQL databases can be downloaded from the <a href="http://ftp.ensemblgenomes.org/pub/current">Ensembl Genomes FTP site</a>. Instructions for loading MySQL dumps onto a local MySQL server can be found in the <a href="/info/docs/webcode/mirror/install/ensembl-data.html">webcode documentation</a>.</p>
+<p>When creating a Ensembl Genomes mirror, or to use local MySQL databases with the Ensembl Perl API, dumps  of MySQL databases can be downloaded from the <a href="https://ftp.ensemblgenomes.org/pub/current">Ensembl Genomes FTP site</a>. Instructions for loading MySQL dumps onto a local MySQL server can be found in the <a href="/info/docs/webcode/mirror/install/ensembl-data.html">webcode documentation</a>.</p>
 
 <h2>Naming conventions</h2>
 

--- a/htdocs/ssi/new.inc
+++ b/htdocs/ssi/new.inc
@@ -4,7 +4,7 @@
 <ul>
 <li>this web browser</li> 
 <li><a href="/biomart/martview/">BioMarts</a> (query optimised data warehouses) constructed for each of the Ensembl Genomes site</li.s
-<li> via FTP (<a href="http://ftp.ensemblgenomes.org/pub">ftp.ensemblgenomes.org/pub</a>) </li>
+<li> via FTP (<a href="https://ftp.ensemblgenomes.org/pub">ftp.ensemblgenomes.org/pub</a>) </li>
 <li>via the Ensembl Genomes public mysql server (mysql.ebi.ac.uk:4157:anonymous). </li>
 <li>using the <a href="/info/data/api.html">Ensembl API</a>.</li>
 </ul>

--- a/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/ToolsTable.pm
@@ -138,7 +138,7 @@ sub render {
       'desc'  => "Parse a vcf file to create a linkage pedigree file (ped) and a marker information file, which together may be loaded into ld visualization tools like Haploview.",
       'tool'  => sprintf('<a href="%s" class="nodeco"><img src="%s16/tool.png" alt="Tool" title="Go to online tool" /></a>', $link, $img_url),
       'limit' => '',
-      'code'  => sprintf('<a href="http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/vcf_to_ped_converter/version_1.1/vcf_to_ped_convert.pl" rel="external" class="nodeco"><img src="%s16/download.png" alt="Download" title="Download Perl script" /></a>', $img_url),
+      'code'  => sprintf('<a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/vcf_to_ped_converter/version_1.1/vcf_to_ped_convert.pl" rel="external" class="nodeco"><img src="%s16/download.png" alt="Download" title="Download Perl script" /></a>', $img_url),
       'docs'  => '',
     });
   }


### PR DESCRIPTION
This PR updates all `http://ftp` URLs to https.
The affected URL hostnames have been tested working with https.
Similar PRs in other repos are listed in the JIRA ticket.
Note: waiting for SSL certificate update in ftp.ensemblgenomes.org

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/