### PR TITLE
Update Pfam URLs

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -439,7 +439,6 @@ MSD                      = http://www.ebi.ac.uk/msd-srv/atlas?id=###ID###
 OMIM                     = http://www.ncbi.nlm.nih.gov/entrez/dispomim.cgi?id=###ID###
 OTHER_FISH_ESTS          = http://ensembl.fugu-sg.org/perl/bioperldbview?format=GenBank;id=###ID###;biodb=other_fish_ests
 OXFORD                   = http://www.well.ox.ac.uk/rat_mapping_resources/
-PFAM                     = http://pfam.xfam.org/family/###ID###
 PFSCAN                   = http://prosite.expasy.org/###ID###
 PIDN                     = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[EMBL_features-prd:###ID###]
 PIRSF                    = http://pir.georgetown.edu/cgi-bin/ipcSF?id=###ID###


### PR DESCRIPTION
This PR updates retired Pfam URLs to the new site (InterPro).
Other affected repos listed in the JIRA ticket.

JIRA: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6701
Sandbox: http://wp-np2-1d.ebi.ac.uk:1640

