### PR TITLE
Remove invalid link

### DIFF
--- a/htdocs/info/genome/compara/pan_compara.html
+++ b/htdocs/info/genome/compara/pan_compara.html
@@ -28,7 +28,7 @@ and orthologies across all the taxonomic groups in Ensmbl and Ensembl Genomes.
 
 <h2>Data Access </h2>
 
-<p>The gene trees obtained from this analysis can be accessed in the <a href="/info/website/tutorials/compara.html">genome browser</a> and also using the <a href="/info/data/api.html">Perl API</a> 
+<p>The gene trees obtained from this analysis can be accessed in the genome browser and also using the <a href="/info/data/api.html">Perl API</a> 
 and <a href="http://rest.ensembl.org">REST API</a>. Note that when using the APIs, 
 the pan-taxonomic comparative genomics data resource can be picked using the name "pan_homology".</p>
 

--- a/htdocs/info/genome/compara/peptide_compara.html
+++ b/htdocs/info/genome/compara/peptide_compara.html
@@ -50,7 +50,7 @@ WGA threshold is 50; no thresholds are applied beyond these clades.</p>
 
 <h2>Data Access</h2>
 
-<p>Interactive gene trees and homologue data can be accessed in the <a href="/info/website/tutorials/compara.html">genome browser</a>, and also with the <a href="/info/data/api.html">Perl API</a> and 
+<p>Interactive gene trees and homologue data can be accessed in the genome browser, and also with the <a href="/info/data/api.html">Perl API</a> and 
 <a href="http://rest.ensembl.org">REST</a> service. Data files are also made available via the 
 Ensembl Genomes <a href="/info/data/ftp/">FTP site</a>.</p>
 


### PR DESCRIPTION
This PR removes an invalid link to a tutorials page in NV sites (tutorial pages are part of the main site).

JIRA: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6714
Sandbox: http://wp-np2-1d.ebi.ac.uk:1640/info/genome/compara/pan_compara.html