### PR TITLE
remove duplicated code

### DIFF
--- a/htdocs/components/EG_01_jquery.dynatree.js
+++ b/htdocs/components/EG_01_jquery.dynatree.js
@@ -30,45 +30,6 @@
 
 var _canLog = true;
 
-function _log(mode, msg) {
-  /**
-   * Usage: logMsg("%o was toggled", this);
-   */
-  if( !_canLog ){
-    return;
-  }
-  // Remove first argument
-  var args = Array.prototype.slice.apply(arguments, [1]);
-  // Prepend timestamp
-  var dt = new Date();
-  var tag = dt.getHours()+":"+dt.getMinutes()+":"+dt.getSeconds()+"."+dt.getMilliseconds();
-  args[0] = tag + " - " + args[0];
-
-  try {
-    switch( mode ) {
-    case "info":
-      window.console.info.apply(window.console, args);
-      break;
-    case "warn":
-      window.console.warn.apply(window.console, args);
-      break;
-    default:
-      window.console.log.apply(window.console, args);
-      break;
-    }
-  } catch(e) {
-    if( !window.console ){
-      _canLog = false; // Permanently disable, when logging is not supported by the browser
-    }
-  }
-}
-
-function logMsg(msg) {
-  Array.prototype.unshift.apply(arguments, ["debug"]);
-  _log.apply(this, arguments);
-}
-
-
 // Forward declaration
 var getDynaTreePersistData = null;
 


### PR DESCRIPTION
After updating the google closure compiler for js minification (https://github.com/Ensembl/ensembl-webcode/pull/947)
the minifier throws 2 errors due multiple function declaration as shown in the screenshot. 
![Screenshot 2022-10-18 at 20 09 20](https://user-images.githubusercontent.com/6347854/211340647-2151edac-faa0-412f-81b4-c6ede11e4b58.png)

Dynatree JS plugin in NV was duplicated in Ensembl when we introduced new species selector. So it is safe to remove it from NVs. The logMsg function calls from this file is tested working successfully.