### PR TITLE
Add configuration to enable VEP/AFDB route

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Tools.pm
+++ b/modules/EnsEMBL/Web/Configuration/Tools.pm
@@ -148,6 +148,13 @@ sub populate_tree {
       )],
       { 'availability' => 1, 'concise' => 'Variant Effect Predictor results', 'no_menu_entry' => "$action/$function" ne 'VEP/Results' }
     ));
+
+    $vep_node->append($self->create_subnode('VEP/AFDB', "AlphaFold Predicted Model",
+      [qw(
+        afdb  EnsEMBL::Web::Component::VEP::AFDB
+      )],
+      { 'availability' => 1, 'concise' => 'AlphaFold Predicted Model', 'no_menu_entry' => "$action/$function" ne 'VEP/AFDB' }
+    ));
   }
 
   ## Assembly converter specific node (doesn't need results page, just a download of file from ticket details)


### PR DESCRIPTION
Adds a missing route for an Alphafold prediction view for VEP results.

Sandbox: http://wp-np2-1e.ebi.ac.uk:8450/

Example input for VEP:

```
1 3452 . T A . . .
3 5087 . C G . . .
2 630 . CA C . . .
```

Jira ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6840

Related PR in public plugins: https://github.com/Ensembl/public-plugins/pull/684