### PR TITLE
Fix ontology term highlighting

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
@@ -19,6 +19,7 @@ limitations under the License.
 package EnsEMBL::Draw::GlyphSet::genetree_legend;
 
 use strict;
+use Data::Dumper;
 
 sub render_normal {
   my ($self) = @_;
@@ -34,7 +35,7 @@ sub render_normal {
   my $highlight_ancestor    = $self->{highlights}->[6];
 # EG highlight ontology terms
   my @ot_terms; 
-  foreach (@{$self->{highlights}->[8]||[]}) {     
+  foreach (split(';', $self->{highlights}->[8]||'')) {
     my ($term) = split(',',  $_);
     push @ot_terms, $term;
   } 


### PR DESCRIPTION
This PR fixes a bug in which prevented highlighting ontology tems in NV genetrees.

The bug stems from the differences in the input variable structure (`$self->{highlights}->[8]`):
* in V sites, the variable is expected to be an array
* in NV sites, the variable is a string (format: `"GO_term,color,gene_id1,gene_id2,...;GO_term,..."`)
the code has been updated in [ensembl-webcode](https://github.com/Ensembl/ensembl-webcode/blob/dc22a2bbcaa239ea360e75f0589cb7704a8ee9c2/modules/EnsEMBL/Draw/GlyphSet/genetree.pm#L75) to reflect this, but not in this repo. This PR aims to fix this.

[Example genetree in a sandbox](http://wp-np2-1d.ebi.ac.uk:1640/Actinia_equina_GCA_011057435.1/Gene/Compara_Tree?g=EGACTEQ4350041359;r=WHPX01001324.1:62642-66571;t=EGACTEQ4350041359-RA)
Expected outcome: selecting a checkbox in the higlight table should draw a highlighted genetree (instead of an error).

<img width="1199" alt="Screenshot-genetree" src="https://github.com/EnsemblGenomes/eg-web-common/assets/1215700/6a24eb75-b47e-4d34-b099-cd9f249bff15">
