### PR TITLE
Save data for highlighting gene ontology terms in gene trees into an array

### DIFF
--- a/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
+++ b/modules/EnsEMBL/Draw/GlyphSet/genetree_legend.pm
@@ -34,7 +34,7 @@ sub render_normal {
   my $highlight_ancestor    = $self->{highlights}->[6];
 # EG highlight ontology terms
   my @ot_terms; 
-  foreach (@{$self->{highlights}->[8]||[]}) {     
+  foreach (@{$self->{highlights}->[8]||[]}) {
     my ($term) = split(',',  $_);
     push @ot_terms, $term;
   } 

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -280,14 +280,17 @@ sub content {
     my @highlight_tags             = split(',',$self->param('ht') || "");
     my $highlight_map = $self->get_highlight_map($cdb,$tree->tree);
     #my @compara_highlights; # not to be confused with COMPARA_HIGHLIGHTS list
+
+    my @ontology_terms = ();
     foreach my $ot_map (@$highlight_map){
       my $xref = $ot_map->{'xref'};
       if ( grep /^$xref$/, @highlight_tags ){
-        push (@highlights, 
+        push (@ontology_terms, 
           sprintf("%s,%s,%s", $xref, $ot_map->{'colour'}, join(',', @{$ot_map->{'members'}})) 
         );
       }
     }
+    push(@highlights, \@ontology_terms);
     #my $compara_highlights_str = join(';',@compara_highlights);
 
   my $image = $self->new_image($tree, $image_config, \@highlights);


### PR DESCRIPTION
## Problem:
Visit metazoa -> gene -> gene tree -> select members to highlight. You will see the following error:

![image](https://github.com/EnsemblGenomes/eg-web-common/assets/6834224/62fb3e2f-6ac2-488f-a647-25a1bfa7ef4c)

_(For context, this error has been around since at least EG release 49 in 2020; see [archive](https://nov2020-metazoa.ensembl.org/Apis_mellifera/Gene/Compara_Tree?g=LOC726692;r=CM009944.2:6529304-6531367;ht=GO:0000785))_

## Investigation
In August 2020, there was a [commit](https://github.com/EnsemblGenomes/eg-web-common/commit/de70161e4e3728b7793c48b8d5a200b2d001fbe4) treating ontology terms in the highlighting function as an array of strings. However, the code that prepared this particular data was not saving it as an dedicated array of strings; but rather the strings were pushed into a parent array — see [the code](https://github.com/EnsemblGenomes/eg-web-common/blob/release/eg/56/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm#L283-L290).

## Decision
Both from Anne's [commit](https://github.com/EnsemblGenomes/eg-web-common/commit/de70161e4e3728b7793c48b8d5a200b2d001fbe4) and from the [code of the ComparaTree module](https://github.com/EnsemblGenomes/eg-web-common/blob/release/eg/56/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm#L283-L290) It seems that the intention of developers was to actually store strings containing gene ontology terms in a dedicated array; so I am updating the code of ComparaTree.pm file accordingly.

## Sandbox
See http://wp-np2-1e.ebi.ac.uk:8440/Apis_mellifera/Gene/Compara_Tree?db=core;g=LOC726692;r=CM009944.2:6529304-6531367;t=XM_006563071

## Related PRs
Needs https://github.com/Ensembl/ensembl-webcode/pull/972 in ensembl-webcode.

**Supersedes** https://github.com/EnsemblGenomes/eg-web-common/pull/114