### PR TITLE
Remove species_url lookups from ComparaHomoeologs

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaHomoeologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaHomoeologs.pm
@@ -76,7 +76,6 @@ sub content {
   
   @rows = ();
   
-  my $lookup = $species_defs->prodnames_to_urls_lookup;
   foreach my $species (sort { ($a =~ /^<.*?>(.+)/ ? $1 : $a) cmp ($b =~ /^<.*?>(.+)/ ? $1 : $b) } keys %homoeologue_list) {
     next if $skipped{$species};
     
@@ -88,7 +87,6 @@ sub content {
       my $homoeologue_desc = $homoeologue->{'homology_desc'};
 
       my $spp = $homoeologue->{'spp'};
-      $spp = $lookup->{$spp};
       my $link_url = $hub->url({
         species => $spp,
         action  => 'Summary',
@@ -169,7 +167,7 @@ sub content {
       });
 
       my $table_details = {
-        'Species'    => join('<br />(', split /\s*\(/, $species_defs->species_label($lookup->{$species})),
+        'Species'    => join('<br />(', split /\s*\(/, $species_defs->species_label($species)),
         'Type'       => $self->html_format ? glossary_helptip($hub, ucfirst $homoeologue_desc, ucfirst "$homoeologue_desc homoeologues").qq{<p class="top-margin"><a href="$tree_url">View Gene Tree</a></p>} : glossary_helptip($hub, ucfirst $homoeologue_desc, ucfirst "$homoeologue_desc homoeologues") ,
         'identifier' => $self->html_format ? $id_info : $stable_id,
         'Target %id' => qq{<span class="$target_class">}.sprintf('%.2f&nbsp;%%', $target).qq{</span>},
@@ -198,7 +196,7 @@ sub content {
       sprintf(
         '<p>%d homoeologues not shown in the table above from the following species. Use the "<strong>Configure this page</strong>" on the left to show them.<ul><li>%s</li></ul></p>',
         $count,
-        join "</li>\n<li>", sort map {$species_defs->species_label($lookup->{$_})." ($skipped{$_})"} keys %skipped
+        join "</li>\n<li>", sort map {$species_defs->species_label($_)." ($skipped{$_})"} keys %skipped
       )
     );
   }   


### PR DESCRIPTION
This PR removes species_url lookups from the `ComparaHomoeologs` module.

The keys of the `%homoeologue_list` are already species_urls, so the lookups are not needed in this case.

This fixes [ENSINT-1638](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1638), as well as a bug whereby the homoeologue "Compare Regions" link was not leading to a region comparison view.

Example in Compara sandbox: http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600;r=3D:379535906-379539827
Example in Plants RC site: https://rc-plants.ensembl.org/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600;r=3D:379535906-379539827
