### PR TITLE
Make various tweaks to Family view

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GeneFamilies.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneFamilies.pm
@@ -91,11 +91,12 @@ sub content {
 
 ### EG Start 
 
+  my $lookup = $species_defs->prodnames_to_urls_lookup;
   if($self->format eq 'Excel'){
 
     my $excel_output = "Gene stable ID, Name, Discription, Taxon ID, Species \n";
     foreach my $member (@{$data->{members}}) {
-      $excel_output .= sprintf('"%s","%s","%s","%s","%s"',$member->{id},$member->{name},$member->{description},$member->{taxon_id},$species_defs->species_display_label($member->{species}));
+      $excel_output .= sprintf('"%s","%s","%s","%s","%s"',$member->{gene_id},$member->{name},$member->{description},$member->{taxon_id},$species_defs->species_label($lookup->{$member->{species}}));
       $excel_output .= "\n";
     }
     return $excel_output;
@@ -171,14 +172,14 @@ sub content {
   
   foreach my $member (@{$data->{members}}) {
 
-    my $species_path = '/' . $member->{species};
+    my $species_path = '/' . $lookup->{$member->{species}};
 
     $table->add_row({
-      id          => '<a href="' . $species_path. '/Gene/Summary?db=core;g=' . $member->{id} . '">' . $member->{id} . '</a>',
+      id          => '<a href="' . $species_path. '/Gene/Summary?db=core;g=' . $member->{gene_id} . '">' . $member->{gene_id} . '</a>',
       name        => $member->{name},
       taxon_id    => $member->{taxon_id},
       description => $member->{description},
-      species     => '<a href="' . $species_path . '">' . $species_defs->species_display_label($member->{species}) . '</a>',
+      species     => '<a href="' . $species_path . '">' . $species_defs->species_label($lookup->{$member->{species}}) . '</a>',
     });
 
     $member_count++;

--- a/modules/EnsEMBL/Web/Component/Gene/GeneFamilySeq.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneFamilySeq.pm
@@ -46,18 +46,20 @@ sub content {
   my $family           = $family_adaptor->fetch_by_stable_id($gene_family_id);
   my @all_members      = @{ $family->get_all_Members };
   my $filtered_data    = $object->filtered_family_data($family);
-  my %filtered_members = map {$_->{id} => $_} @{$filtered_data->{members}};
+  my %filtered_members = map {$_->{species} . '|' . $_->{id} => $_} @{$filtered_data->{members}};
   my $html = '';
 
+  my $lookup = $species_defs->prodnames_to_urls_lookup;
   foreach my $member (@all_members) {
     my $member_id   = $member->stable_id;
-    my $member_data = $filtered_members{$member_id};
+    my $member_key  = $member->genome_db->name . '|' . $member_id;
+    my $member_data = $filtered_members{$member_key};
     next unless $member_data;
 
     my $sequence = $member->sequence;
     next unless $sequence;
 
-    my $title = join ' ', $member_id, $member_data->{description}, '('.$species_defs->species_display_label($member_data->{species}).')';
+    my $title = join ' ', $member_id, $member_data->{description}, '('.$species_defs->species_label($lookup->{$member_data->{species}}).')';
     $title   .= " (gene=$member_data->{name})" if $member_data->{name};
 
     if($format =~ /^text$/i){

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -199,9 +199,9 @@ sub filtered_family_data {
   if(!@$members) {
     my $member_objs = $family->get_all_Members;
 
-    # API too slow, use raw SQL to get name and desc for all genes   
+    # API too slow, use raw SQL to get stable_id, name and desc for all genes
     my $gene_info = $self->database('compara')->dbc->db_handle->selectall_hashref(
-      'SELECT g.gene_member_id, g.display_label, g.description FROM family f 
+      'SELECT g.gene_member_id, g.stable_id, g.display_label, g.description FROM family f
        JOIN family_member fm USING (family_id) 
        JOIN seq_member s USING (seq_member_id) 
        JOIN gene_member g USING (gene_member_id) 
@@ -215,6 +215,7 @@ sub filtered_family_data {
       my $gene = $gene_info->{$member->gene_member_id};
       push (@$members, {
         name        => $gene->{display_label},
+        gene_id     => $gene->{stable_id},
         id          => $member->stable_id,
         taxon_id    => $member->taxon_id,
         description => $gene->{description},


### PR DESCRIPTION
This PR makes various tweaks to the Family view:
- the `$species_defs->prodnames_to_urls_lookup` is used to fetch the species display name for each family member, in line with current usage elsewhere in Ensembl web code;
- the gene stable ID is displayed in the "Gene stable ID" column; and
- in `EnsEMBL::Web::Component::Gene::GeneFamilySeq`, filtered members are matched by a concatenation of production name and translation stable ID, to make the Family sequence download functionality more robust against stable ID clashes.

Example in sandbox: http://wp-np2-25.ebi.ac.uk:5091/Schizophyllum_commune_h4_8_gca_000143185/Gene/Gene_families?db=core;g=SCHCODRAFT_107723
