### PR TITLE
Use Pan species URL lookup, fix highlighted gene ID

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -128,7 +128,16 @@ sub content {
     $current_gene_display_name = $hub->param('g');
   }
 
-  my $lookup = $sd->prodnames_to_urls_lookup;
+  my $lookup;
+  if ($cdb =~ /pan/) {
+    my $pan_info = $hub->species_defs->multi_val('PAN_COMPARA_LOOKUP');
+    foreach (keys %$pan_info) {
+      $lookup->{$_} = $pan_info->{$_}{'species_url'};
+    }
+  }
+  else {
+    $lookup = $sd->prodnames_to_urls_lookup;
+  }
   
   foreach my $this_leaf (@$leaves) {
     if ($gene_to_highlight && $this_leaf->gene_member->stable_id eq $gene_to_highlight) {

--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -120,12 +120,18 @@ sub content {
 
   # store g1 param in a different param as $highlight_gene can be undef if highlighting is disabled
   my $gene_to_highlight = $hub->param('g1');
-  my $highlight_gene_display_label;
+  my $current_gene_display_name;
+
+  if ($gene && defined $gene->Obj->display_xref) {
+    $current_gene_display_name = $gene->Obj->display_xref->display_id;
+  } else {
+    $current_gene_display_name = $hub->param('g');
+  }
+
   my $lookup = $sd->prodnames_to_urls_lookup;
   
   foreach my $this_leaf (@$leaves) {
     if ($gene_to_highlight && $this_leaf->gene_member->stable_id eq $gene_to_highlight) {
-      $highlight_gene_display_label = $this_leaf->gene_member->display_label || $gene_to_highlight;
       $highlight_species            = $lookup->{$this_leaf->gene_member->genome_db->name};
       $highlight_species_name       = $this_leaf->gene_member->genome_db->display_name;
       $highlight_genome_db_id       = $this_leaf->gene_member->genome_db_id;
@@ -145,7 +151,7 @@ sub content {
           sprintf(
             '<p>The <i>%s</i> %s gene, its paralogues, its orthologue in <i>%s</i>, and paralogues of the <i>%s</i> gene, have all been highlighted. <a href="#" class="switch_highlighting on">Click here to disable highlighting</a>.</p>',
             $sd->get_config($lookup->{$member->genome_db->name}, 'SPECIES_DISPLAY_NAME'),
-            $highlight_gene_display_label,
+            $current_gene_display_name,
             $sd->get_config($highlight_species, 'SPECIES_DISPLAY_NAME') || $highlight_species_name,
             $sd->get_config($highlight_species, 'SPECIES_DISPLAY_NAME') || $highlight_species_name
           )
@@ -168,7 +174,7 @@ sub content {
         sprintf(
           '<p>The <i>%s</i> %s gene and its paralogues are highlighted. <a href="#" class="switch_highlighting off">Click here to enable highlighting of %s homologues</a>.</p>',
           $sd->get_config($lookup->{$member->genome_db->name}, 'SPECIES_DISPLAY_NAME'),
-          $highlight_gene_display_label,
+          $current_gene_display_name,
           $sd->get_config($highlight_species, 'SPECIES_DISPLAY_NAME') || $highlight_species_name
         )
       );


### PR DESCRIPTION
This PR changes the Compara tree view in two ways:
- The "Highlighted genes" infobox currently takes the name of the query gene from the `g1` parameter rather than the `g` parameter, causing the orthology target gene to be named as being in the species of the query gene in the highlighted gene tree view ([ENSWEB-6880](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6880)). The issue was previously reported and fixed in `ensembl-webcode` as [ENSWEB-6591](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6591), and this PR applies the same fix in `eg-web-common`. (In the example links, look for the gene name AT1G07820 in the "Highlighted genes" infobox.)
- URL lookup is taken from `PAN_COMPARA_LOOKUP` for Pan Compara gene trees, which fixes a bug whereby orthologues were not being highlighted in gene trees accessed via the Pan Compara orthologue table. (In the example links, look for the Chicken orthologue ENSGALG00010012179 in the gene tree.)

Example in Plants staging: http://staging-plants.ensembl.org/Arabidopsis_thaliana/Gene/PanComparaTree?anc=6201892;db=core;g=AT1G07820;g1=ENSGALG00010012179
Example in Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/PanComparaTree?anc=6201892;db=core;g=AT1G07820;g1=ENSGALG00010012179
