### PR TITLE
Add spaces between elements in homoeolog table cells

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaHomoeologs.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaHomoeologs.pm
@@ -150,13 +150,13 @@ sub content {
         $description   .= sprintf '[Source: %s; acc: %s]', $edb, $hub->get_ExtURL_link($acc, $edb, $acc) if $acc;
       }
       
-      my $id_info;
+      my @id_info_parts;
       if (!$homoeologue->{'display_id'} || $homoeologue->{'display_id'} eq 'Novel Ensembl prediction') {
-        $id_info = qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>};
+        push(@id_info_parts, qq{<p class="space-below"><a href="$link_url">$stable_id</a></p>});
       } else {
-        $id_info = qq{<p class="space-below">$homoeologue->{'display_id'}&nbsp;&nbsp;<a href="$link_url">($stable_id)</a></p>};
+        push(@id_info_parts, qq{<p class="space-below">$homoeologue->{'display_id'}&nbsp;&nbsp;<a href="$link_url">($stable_id)</a></p>});
       }
-      $id_info .= qq{<p class="space-below">$region_link</p><p class="space-below">$alignment_link</p>};
+      push(@id_info_parts, (qq{<p class="space-below">$region_link</p>}, qq{<p class="space-below">$alignment_link</p>}));
 
       ##Location - split into elements to reduce horizonal space
       my $location_link = $hub->url({
@@ -168,10 +168,13 @@ sub content {
         __clear => 1
       });
 
+      my @homology_type_parts = (glossary_helptip($hub, ucfirst $homoeologue_desc, ucfirst "$homoeologue_desc homoeologues"));
+      push(@homology_type_parts, qq{<p class="top-margin"><a href="$tree_url">View Gene Tree</a></p>}) if $self->html_format;
+
       my $table_details = {
         'Species'    => join('<br />(', split /\s*\(/, $species_defs->species_label($species)),
-        'Type'       => $self->html_format ? glossary_helptip($hub, ucfirst $homoeologue_desc, ucfirst "$homoeologue_desc homoeologues").qq{<p class="top-margin"><a href="$tree_url">View Gene Tree</a></p>} : glossary_helptip($hub, ucfirst $homoeologue_desc, ucfirst "$homoeologue_desc homoeologues") ,
-        'identifier' => $self->html_format ? $id_info : $stable_id,
+        'Type'       => join(' ', @homology_type_parts),
+        'identifier' => $self->html_format ? join(' ', @id_info_parts) : $stable_id,
         'Target %id' => qq{<span class="$target_class">}.sprintf('%.2f&nbsp;%%', $target).qq{</span>},
         'Query %id'  => qq{<span class="$query_class">}.sprintf('%.2f&nbsp;%%', $query).qq{</span>},
       };      


### PR DESCRIPTION
## Description

To facilitate testing, this PR — in conjunction with [ensembl-webcode PR 1018](https://github.com/Ensembl/ensembl-webcode/pull/1018) — adds spacing between elements within the same cell of an orthology/paralogy/homoeology table view.

## Views affected

This set of changes primarily affects the spacing of elements within text files downloaded from orthologue, paralogue and homoeologue views.

Examples:
- Orthologues: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Ortholog?g=FBgn0014857) vs [staging site](https://staging-metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Ortholog?g=FBgn0014857)
- Paralogues: [sandbox](http://wp-np2-25.ebi.ac.uk:5094/Drosophila_melanogaster/Gene/Compara_Paralog?g=FBgn0014857) vs [staging site](https://staging-metazoa.ensembl.org/Drosophila_melanogaster/Gene/Compara_Paralog?g=FBgn0014857)
- Homoeologues: [sandbox](http://wp-np2-25.ebi.ac.uk:5098/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600) vs [live site](https://plants.ensembl.org/Triticum_aestivum/Gene/Compara_Homoeolog?g=TraesCS3D02G273600)

## Possible complications

No complications expected.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

N/A
