### PR TITLE
Include multiple alignments in alignment count

### DIFF
--- a/modules/EnsEMBL/Web/Object/Location.pm
+++ b/modules/EnsEMBL/Web/Object/Location.pm
@@ -35,7 +35,7 @@ sub counts {
   my $self = shift;
   $self->PREV::counts(@_);
   my $alignments = $self->count_alignments;
-  $self->{_counts}->{"alignments"} = $alignments->{pairwise};
+  $self->{_counts}->{"alignments"} = $alignments->{pairwise} + $alignments->{multi};
   $self->{_counts}->{"intraspecies_alignments"} = $alignments->{patch};
   return $self->{_counts};
 }


### PR DESCRIPTION
This PR includes `multi` alignments in the `alignments` count, with two main effects:
1. a more accurate alignment account; and
2. accessibility of genomic alignments in species that have multiple alignment data but lack pairwise alignment data.

Here is an example of the benefits to data accessibility: the images below show menu items for a genome in the Drosophila pangenome `CACTUS_DB` alignment in the Compara sandbox, before this change...

![before](https://github.com/EnsemblGenomes/eg-web-common/assets/84317604/ce6bd7ed-4ddf-4bf3-93bc-0520d32ec8dd)

...and after this change:

![after](https://github.com/EnsemblGenomes/eg-web-common/assets/84317604/3c7edfb7-aa22-4527-91f3-471fb778e55e)
