### PR TITLE
Remove redundant copy of _summarise_pan_compara

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -67,59 +67,6 @@ sub _homologies_sql {
   );
 }
 
-sub _summarise_pan_compara {
-  my ($self, $dbh) = @_;
-
-  ## Get info about pan-compara species
-  my $metadata_db = $self->full_tree->{MULTI}->{databases}->{DATABASE_METADATA};
-  my $meta_dbh = $self->db_connect('DATABASE_METADATA', $metadata_db);
-  my $version = $SiteDefs::ENSEMBL_VERSION;
-  my $aref = $meta_dbh->selectall_arrayref(
-      "select 
-          o.name, o.url_name, o.display_name, o.scientific_name, d.name 
-        from 
-          organism as o, genome as g, data_release as r, division as d 
-        where 
-          o.organism_id = g.organism_id 
-          and g.data_release_id = r.data_release_id 
-          and g.division_id = d.division_id
-          and g.has_pan_compara = 1
-          and r.ensembl_version = $version"
-      );    
-  ## Also get info about Archaea from pan-compara itself, for bacteria
-  my $archaea = {};
-  my $bref = $dbh->selectall_arrayref(
-          "select 
-            g.name from ncbi_taxa_node a 
-          join 
-            ncbi_taxa_name an using (taxon_id) 
-          join 
-            ncbi_taxa_node c on (c.left_index>a.left_index and c.right_index<a.right_index) 
-          join 
-            genome_db g on (g.taxon_id=c.taxon_id) 
-          where 
-            an.name='Archaea' 
-            and an.name_class='scientific name'
-  ");
-  $archaea->{$_->[0]} = 1 for @$bref;
-
-  foreach my $row (@$aref) {
-    my ($prod_name, $url, $display_name, $sci_name, $division) = @$row;
-    $division =~ s/Ensembl//;
-    my $subdivision;
-    if ($division eq 'Bacteria') {
-      $subdivision = 'archaea' if $archaea->{$prod_name};
-    }
-    $self->db_tree->{'PAN_COMPARA_LOOKUP'}{$prod_name} = {
-                'species_url'     => $url,
-                'display_name'    => $display_name,
-                'scientific_name' => $sci_name,
-                'division'        => lc $division,
-                'subdivision'     => $subdivision,
-    };
-  }
-}
-
 sub _go_sql {
   return qq(
     SELECT o.ontology_id, o.name, t.accession, t.name 


### PR DESCRIPTION
This PR would delete the `ConfigPacker::_summarise_pan_compara` method from `eg-web-common`.

This method is almost identical to [its counterpart in ensembl-webcode](https://github.com/Ensembl/ensembl-webcode/blob/d72e87e9f7ebace5dcad598fe876929f6d937420/modules/EnsEMBL/Web/ConfigPacker.pm#L1973-L2026), and because `$subdivision` is only defined for Bacteria, its output is effectively identical in practice.

Removing this copy of the `_summarise_pan_compara` method will save having to keep both copies of the method in sync.
