### PR TITLE
Facilitate CACTUS_DB alignment views in NV divisions

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -39,6 +39,15 @@ sub content {
 
   return $self->_error('Unknown alignment', '<p>The alignment you have selected does not exist in the current database.</p>') unless $align_details;
   
+  ## Check for wrong component in per-component polyploid alignments.
+  my $warning_box = $self->check_for_wrong_genome_component({
+    'cdb'   => $self->param('cdb') || 'compara',
+    'align' => $align,
+    'slice' => $object->slice,
+  });
+  return $warning_box if $warning_box;
+  ##
+
   my $primary_species = $hub->species; 
   my $prodname        = $species_defs->SPECIES_PRODUCTION_NAME;
   
@@ -62,6 +71,10 @@ sub content {
   my $lookup          = $species_defs->prodnames_to_urls_lookup;
   my (@images, $html);
   
+  if ($align_details->{'type'} eq 'CACTUS_DB') {
+    $html .= $self->show_scale_dependent_track_info_box($align_details);
+  }
+
   my ($caption_height,$caption_img_offset) = (0,-24);
   foreach (@$slices) {
     my $species      = $_->{'name'} eq 'Ancestral_sequences' ? 'Multi' : $lookup->{$_->{'name'}}; # Cheating: set species to Multi to stop errors due to invalid species.


### PR DESCRIPTION
In conjunction with [ensembl-webcode PR 1061](https://github.com/Ensembl/ensembl-webcode/pull/1061) and [eg-web-plants PR 76](https://github.com/EnsemblGenomes/eg-web-plants/pull/76), this PR would facilitate display of Non-Vertebrate `CACTUS_DB` alignments.

It would:
- display a 'scale-dependent track config' info box in image alignment views if any tracks are hidden; and
- display a warning box in image genomic alignment views if the user tries to access a per-subgenome alignment from the wrong subgenome, and if possible, recommend the appropriate per-subgenome alignment.

## Possible complications

No complications are expected.

Method `show_scale_dependent_track_info_box` should only be called for `CACTUS_DB` alignments, as intended.

Method `check_for_wrong_genome_component` is a stub in every division except Plants, and in Plants its effect is limited to `CACTUS_DB` alignments with a `genome_component` MLSS tag. It should only have an effect on the intended genomic alignments.