### PR TITLE
Show species sprites in genomic alignment view

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -98,7 +98,7 @@ sub content {
     my $asb = $image_config->get_node('alignscalebar');
     $asb->set_data('caption', $panel_caption);
     $asb->set_data('caption_position', 'bottom');
-    $asb->set_data('caption_img',"f:24\@$caption_img_offset:".$_->{'name'});
+    $asb->set_data('caption_img',"f:24\@$caption_img_offset:".$species_defs->get_config($species, 'SPECIES_IMAGE'));
     $asb->set_data('caption_height',$caption_height);
     $caption_img_offset = -20;
     $caption_height = 28;


### PR DESCRIPTION
This PR would access the `SPECIES_IMAGE` config for each extant species in genomic alignment image views, thereby enabling species sprites to be shown.

Example genomic alignment image view before this change:
![rice_epo_image_view_before](https://github.com/user-attachments/assets/00958031-b645-4854-8789-973f69cd447d)

Example genomic alignment image view after this change:
![rice_epo_image_view_after](https://github.com/user-attachments/assets/8aaceb6a-4602-4db2-9ab3-ac886467c4b0)