### PR TITLE
Summarise intraspecies alignments in NV divisions

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -31,10 +31,6 @@ sub munge_config_tree {
   $self->_configure_external_resources;
 }
 
-sub _summarise_compara_alignments {
-  ## EG - now done on the fly - too many alignments to put in configs 
-}
-
 sub _intraspecies_sql {
 ## need to exclude HOMOEOLOGUES as well as PARALOGUES otherwise too many method link species sets that prevents web site from starting
   return qq(


### PR DESCRIPTION
## Description

This PR would remove the dummy method `ConfigPacker::_summarise_compara_alignments` from `eg-web-common`, enabling the use of the [ConfigPacker::_summarise_compara_alignments method in ensembl-webcode](https://github.com/Ensembl/ensembl-webcode/blob/dcb909d9d01627535cbaeffcbf8f1844e24227cb/modules/EnsEMBL/Web/ConfigPacker.pm#L1410-L1581).

The practical consequence of this would be that Compara alignment summaries would be computed in Ensembl Plants for the following intra-species alignments and packed into the Plants `MULTI.db.packed` file:
- `Taes LastZ (self-alignment)`
- `Taes polyploidy-aware self-alignment`
- `Tdic LastZ (self-alignment)`
- `Tdic polyploidy-aware self-alignment`

The main benefit of this is that the alignment summaries restore the `Polyploid` alignment view for T. aestivum and T. dicoccoides.

## Views affected

This change primarily affects the polyploid alignment view.

Example of T. aestivum alignment before this change:
![wheat_polyploid_view_before](https://github.com/user-attachments/assets/9ae857be-6fbd-4f8f-8e67-97aaf88e2861)

Example of T. aestivum alignment after this change:
![wheat_polyploid_view_after](https://github.com/user-attachments/assets/1e72eb9f-63ea-48ad-9840-0ac28ea7bea0)

## Possible complications

Because removal of this dummy method would lead to computation of region summaries of intraspecies alignments in Ensembl Plants, this would result in a Plants `MULTI.db.packed` file that is ~8% larger.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- ENSCOMPARASW-8037