### PR TITLE
Load underlying slices iff needed for alignslice view

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -59,11 +59,13 @@ sub content {
     ));
   }
   
+  my $need_underlying_slices = !$self->has_image || $align_details->{'class'} eq 'GenomicAlignTree.ancestral_alignment';
   my $image_width     = $self->image_width;
   my $slice           = $object->slice;
   my ($slices)        = $object->get_slices({
                                               'slice' => $slice, 
                                               'align' => $align_params, 
+                                              'image' => !$need_underlying_slices,
                                               'species' => $primary_species
                         });
   my %aligned_species = map { $_->{'name'} => 1 } @$slices;
@@ -130,6 +132,7 @@ sub content {
   my ($alert_box, $error) = $self->check_for_align_problems({
                                 'align'   => $align, 
                                 'species' => $prodname, 
+                                'image'   => !$need_underlying_slices,
                                 'cdb'     => $self->param('cdb') || 'compara',
                                 });
 


### PR DESCRIPTION
This PR would set the `get_slices` `'image'` parameter to `0` for genomic alignment image views lacking an ancestral sequence (i.e. not of class `GenomicAlignTree.ancestral_alignment`). Tests so far have indicated that this can reduce multiple genomic alignment loading times by ~10% on average.

See [ensembl-webcode PR 1076](https://github.com/Ensembl/ensembl-webcode/pull/1076) for more information.