### PR TITLE
Update Pan FTP links to reflect current FTP dump locations

### DIFF
--- a/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/FTPtable.pm
@@ -53,9 +53,9 @@ sub multi_table {
       {
       database => qq{<strong>Pan_compara Multi-species</strong>},
       mysql   => qq{<a rel="external" title="$title{pan}" href="$ftp/pan_ensembl/release-$rel/mysql/$pan_compara/">MySQL</a>},
-      emf     => qq{<a rel="external" title="$title{emf}" href="$ftp/pan_ensembl/release-$rel/emf/ensembl-compara/homologies">EMF</a>},
-      tsv     => qq{<a rel="external" title="$title{tsv}" href="$ftp/pan_ensembl/release-$rel/tsv/ensembl-compara/homologies">TSV</a>},
-      xml     => qq{<a rel="external" title="$title{xml}" href="$ftp/pan_ensembl/release-$rel/xml/ensembl-compara/homologies">XML</a>},
+      emf     => qq{<a rel="external" title="$title{emf}" href="$ftp/release-$rel/pan/emf/ensembl-compara/homologies">EMF</a>},
+      tsv     => qq{<a rel="external" title="$title{tsv}" href="$ftp/release-$rel/pan/tsv/ensembl-compara/homologies">TSV</a>},
+      xml     => qq{<a rel="external" title="$title{xml}" href="$ftp/release-$rel/pan/xml/ensembl-compara/homologies">XML</a>}
       },
       {
       database => qq{<strong>$multi_sp Multi-species</strong>},


### PR DESCRIPTION
This PR would update the Pan FTP links on the **FTP Download** page (e.g. [e114 Metazoa FTP download page](https://metazoa.ensembl.org/info/data/ftp/index.html)) so that they each point to the current location of their respective FTP dump files.

It's been marked as ready for review following confirmation that these are indeed the intended locations of the Pan Compara FTP dump files for e114.

Further changes are expected in e115, but this will not necessarily involve reversions of these changes.