### PR TITLE
Move scale-dependent track config from Vertebrates

### DIFF
--- a/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
+++ b/modules/EnsEMBL/Web/ImageConfigExtension/Tracks.pm
@@ -27,6 +27,8 @@ use strict;
 use warnings;
 no warnings qw(uninitialized);
 
+use previous qw (add_genes);
+
 our $pretty_method = {
   BLASTZ_NET          => 'BlastZ',
   LASTZ_NET           => 'LastZ',
@@ -34,6 +36,48 @@ our $pretty_method = {
   SYNTENY             => 'Synteny',
   ATAC                => 'ATAC',
 };
+
+sub add_genes {
+  my $self = shift;
+
+  $self->PREV::add_genes(@_);
+
+  # If this is an alignslice track in a large-scale CACTUS_DB alignment
+  # view, disable selected tracks in order to reduce load times.
+  if ($self->type eq 'alignsliceviewbottom') {
+
+    my $align_id = exists $self->hub->referer->{'params'}{'align'}
+                 ? $self->hub->referer->{'params'}{'align'}[0]
+                 : $self->hub->get_alignment_id
+                 ;
+
+    if ($align_id) {
+      my $align_details = $self->species_defs->multi_hash->{'DATABASE_COMPARA'}->{'ALIGNMENTS'}->{$align_id};
+      if ($align_details->{'type'} eq 'CACTUS_DB' && exists $align_details->{'as_track_threshold_data'}) {
+        my $location_param = $self->hub->referer->{'params'}{'r'}[0];
+
+        my $location_length;
+        if ($location_param =~ /^[\w\.\-]+:(\d+)\-(\d+)$/) {  # region pattern from MetaKeyFormat datacheck
+          $location_length = abs($2 - $1) + 1;
+        } else {
+          $location_length = 1;  # This should never happen, but if it does, we revert to default behaviour.
+        }
+
+        my $as_track_thresholds = $align_details->{'as_track_threshold_data'};
+        if (exists $as_track_thresholds->{'transcript'} && $location_length >= $as_track_thresholds->{'transcript'}) {
+
+          # At large scales, disable transcript tracks.
+          $self->modify_configs(['transcript'], { 'display' => 'off' });
+
+          if (exists $as_track_thresholds->{'sequence'} && $location_length >= $as_track_thresholds->{'sequence'}) {
+            # At larger scales still, disable sequence tracks.
+            $self->modify_configs(['sequence'], { 'display' => 'off' });
+          }
+        }
+      }
+    }
+  }
+}
 
 sub add_protein_features {
   my ($self, $key, $hashref) = @_;


### PR DESCRIPTION
In conjunction with [ensembl-webcode PR 1082](https://github.com/Ensembl/ensembl-webcode/pull/1082), this PR would make scale-dependent track config code apply only to Non-Vertebrate `CACTUS_DB` alignments.

It would introduce an `add_genes` method to the `EnsEMBL::Web::ImageConfigExtension::Tracks` module, which would call the previous `add_genes` method in `ensembl-webcode`.

This NV-specific `add_genes` method would apply scale-dependent track configuration to Non-Vertebrate `CACTUS_DB` image views.

## Possible complications

No complications are expected, because the relevant code is effectively being moved here from `ensembl-webcode`.

## Merge conflicts

None detected.