### PR TITLE
Set image parameter according to has_image

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -59,13 +59,12 @@ sub content {
     ));
   }
   
-  my $need_underlying_slices = !$self->has_image || $align_details->{'class'} eq 'GenomicAlignTree.ancestral_alignment';
   my $image_width     = $self->image_width;
   my $slice           = $object->slice;
   my ($slices)        = $object->get_slices({
                                               'slice' => $slice, 
                                               'align' => $align_params, 
-                                              'image' => !$need_underlying_slices,
+                                              'image' => $self->has_image,
                                               'species' => $primary_species
                         });
   my %aligned_species = map { $_->{'name'} => 1 } @$slices;
@@ -132,7 +131,7 @@ sub content {
   my ($alert_box, $error) = $self->check_for_align_problems({
                                 'align'   => $align, 
                                 'species' => $prodname, 
-                                'image'   => !$need_underlying_slices,
+                                'image'   => $self->has_image,
                                 'cdb'     => $self->param('cdb') || 'compara',
                                 });
 


### PR DESCRIPTION
In light of the acceptance of [ensembl-webcode PR 1078](https://github.com/Ensembl/ensembl-webcode/pull/1078), it is not necessary to load underlying slices for EPO image alignments (e.g. Rice EPO).

This PR would change the behaviour of the `eg-web-common` `Compara_AlignSliceBottom` so that it would match the behaviour of the corresponding `ensembl-webcode` `Compara_AlignSliceBottom` and no longer trigger fetching of underlying slices in such cases.
