### PR TITLE
Match highlighted orthologue by gene and genome

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTree.pm
@@ -142,9 +142,12 @@ sub content {
   }
   
   foreach my $this_leaf (@$leaves) {
+    # If the 's1' parameter is specified, we need $highlight_species_url to match the species URL
+    # of $gene_to_highlight ... but it's entirely possible the 's1' parameter will not be specified;
+    # in such cases, we must allow for a highlighted gene to be matched by stable ID alone.
     if ($gene_to_highlight
         && $this_leaf->gene_member->stable_id eq $gene_to_highlight
-        && $lookup->{$this_leaf->gene_member->genome_db->name} eq $highlight_species_url) {
+        && (!defined $highlight_species_url || $lookup->{$this_leaf->gene_member->genome_db->name} eq $highlight_species_url)) {
       $highlight_species            = $lookup->{$this_leaf->gene_member->genome_db->name};
       $highlight_species_name       = $this_leaf->gene_member->genome_db->display_name;
       $highlight_genome_db_id       = $this_leaf->gene_member->genome_db_id;


### PR DESCRIPTION
In conjunction with [ensembl-webcode PR 1091](https://github.com/Ensembl/ensembl-webcode/pull/1091) and [eg-web-metazoa PR 46](https://github.com/EnsemblGenomes/eg-web-metazoa/pull/46), this PR would:
- add an `s1` parameter to gene-tree views, which contains the species URL of the genome containing the gene specified by `g1`; and
- use the species indicated by `s1` to help unambiguously identify the gene specified by `g1` for highlighting in a given gene-tree view.
