### PR TITLE
Tweak comparative UI elements in Non-Vertebrate divisions

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/ComparaTreeSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/ComparaTreeSummary.pm
@@ -130,7 +130,7 @@ sub highlight_tags_table {
       ht => $hub->get_ExtURL_link($xref,$db_name,$xref),
       highlight => sprintf(qq{<input class="%04d_members update_genetree" %s type="radio" name="highlight_tag_selector" value="%s"/>%s},$count,$checked,$update_url,$text),
       description=> $desc,
-      options => {class => "type_any type_$db_name"},
+      options => {class => "all type_$db_name"},
     });
   }
   my $table = $self->new_table(
@@ -177,8 +177,15 @@ sub highlight_types_selector {
   my $meta = $self->dom->create_element('div', {class=>'ht_table', style=>''});
   my $form = $meta->append_child('div',{class=>sprintf('toggleable toggleTable_wrapper_no_margin %s', $hide ? 'hide':'')});
   $form->append_child('span',{inner_HTML=>'Show '});
-  for my $db_name (keys %types){
-    $form->append_child('input',{name=>'ht_table',class=>'table_filter',type=>'checkbox', checked=>1, value=>"type_$db_name"});
+
+  my @db_names = sort keys %types;
+  if (scalar @db_names > 0) {
+    $form->append_child('input',{name=>'ht_table',class=>'table_filter',type=>'checkbox', checked=>1, value=>'all'});
+    $form->append_child('label',{inner_HTML=>'All'});
+  }
+
+  for my $db_name (@db_names){
+    $form->append_child('input',{name=>'ht_table',class=>'table_filter',type=>'checkbox', value=>"type_$db_name"});
     $form->append_child('label',{inner_HTML=>sprintf("%s ",$db_name)});
   }
 

--- a/modules/EnsEMBL/Web/Component/Gene/Compara_Portal.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/Compara_Portal.pm
@@ -1,0 +1,29 @@
+=head1 LICENSE
+
+Copyright [2009-2025] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Component::Gene::Compara_Portal;
+
+use strict;
+
+use parent qw(EnsEMBL::Web::Component::Gene);
+
+sub _get_compara_family_page_action {
+    return 'Gene_families';
+}
+
+1;

--- a/modules/EnsEMBL/Web/Component/Gene/GeneFamilies.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneFamilies.pm
@@ -162,7 +162,7 @@ sub content {
       sorting => [ 'species asc' ], 
       class => 'no_col_toggle',
       data_table => 1, 
-      data_table_config => { iDisplayLength => 25, aLengthMenu => [[25, 50, 100, -1], [25, 50, 100, "All"]] },
+      data_table_config => { iDisplayLength => 25, aLengthMenu => [[25, 50, 100, 500], [25, 50, 100, 500]] },
     }
   );
 


### PR DESCRIPTION
## Description

In conjunction with an ensembl-webcode PR, this pull request tweaks several comparative UI elements in Non-Vertebrate divisions.

Changes include:
1. Addition of an `"All"` option to the Gene tree highlighting annotations table, which addresses the issue reported in [ENSWEB-6936](https://embl.atlassian.net/browse/ENSWEB-6936).
2. Replacement of the `"All"` option with `500` in the table limit dropdown of the Gene families table, addressing [ENSCOMPARASW-8605](https://embl.atlassian.net/browse/ENSCOMPARASW-8605).
3. Addition of an NV-specific `EnsEMBL::Web::Component::Gene::Compara_Portal::_get_compara_family_page_action` method, which has the effect of fixing broken "Family" links in Microbes Compara portal pages.

## Views affected

Examples for yeast gene TAZ1:
1. Gene tree highlighting: [sandbox](http://wp-np2-35.ebi.ac.uk:5091/Saccharomyces_cerevisiae/Gene/Compara_Tree?db=core;g=YPR140W) vs [live site](https://fungi.ensembl.org/Saccharomyces_cerevisiae/Gene/Compara_Tree?db=core;g=YPR140W)
2. Gene families table limit dropdown: [sandbox](http://wp-np2-35.ebi.ac.uk:5091/Saccharomyces_cerevisiae/Gene/Gene_families?db=core;g=YPR140W) vs [live site](https://fungi.ensembl.org/Saccharomyces_cerevisiae/Gene/Gene_families?db=core;g=YPR140W)
3. Compara portal family link: [sandbox](http://wp-np2-35.ebi.ac.uk:5091/Saccharomyces_cerevisiae/Gene/Compara?db=core;g=YPR140W) vs [live site](https://fungi.ensembl.org/Saccharomyces_cerevisiae/Gene/Compara?db=core;g=YPR140W)

## Possible complications

None expected, as each change should affect only its respective view.

Changes in Compara portal views should only be apparent in Non-Vertebrate sites with InterPro family data (i.e. Fungi, Protists, Bacteria). (If a Compara database lacks family data, Compara portal family links are inactive.)

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- [ENSCOMPARASW-8605](https://embl.atlassian.net/browse/ENSCOMPARASW-8605)
- [ENSWEB-6936](https://embl.atlassian.net/browse/ENSWEB-6936)