### PR TITLE
Set Bacteria-specific action for protein summary and sequence links

### DIFF
--- a/modules/EnsEMBL/Web/ZMenu/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Gene/ComparaTree.pm
@@ -52,13 +52,23 @@ sub content {
   });
 
   if ($ens_prot) {
+
+    my ($prot_summary_action, $prot_sequence_action);
+    if ($hub->species_defs->GENOMIC_UNIT eq 'bacteria') {
+      $prot_summary_action = sprintf('ProteinSummary_%s', $ens_prot->stable_id);
+      $prot_sequence_action = sprintf('Sequence_Protein_%s', $ens_prot->stable_id);
+    } else {
+      $prot_summary_action = 'ProteinSummary';
+      $prot_sequence_action = 'Sequence_Protein';
+    }
+
     $self->add_entry({
       type     => 'Protein',
       label    => 'Summary',
       position => 5,
       link     => $hub->url({
         type   => 'Transcript',
-        action => 'ProteinSummary',
+        action => $prot_summary_action,
         t      => $ens_tran->stable_id 
       })
     });
@@ -69,7 +79,7 @@ sub content {
       position => 6,
       link     => $hub->url({
         type   => 'Transcript',
-        action => 'Sequence_Protein',
+        action => $prot_sequence_action,
         t      => $ens_tran->stable_id 
       })
     });


### PR DESCRIPTION
Protein summary and sequence links are broken in bacterial ZMenus in Pan Compara gene trees.

For example, if you go to the [EGGT00050000005387 gene tree view](https://plants.ensembl.org/Multi/GeneTree/Image/pan_compara?gt=EGGT00050000005387) and click on any of the bacterial gene labels, then click on its ZMenu links to see the "Protein Summary" or "Protein Sequence", the linked page contains the text:

> Sorry, this page is not available for this feature. Please select a valid link from the menu on the left.

This seems to be happening because protein summary and sequence pages have a different format in Ensembl Bacteria, in which the protein stable ID is concatenated to the action string.

This PR should mend these broken links by using the Bacteria-specific action when a gene-tree member gene ZMenu is requested from Ensembl Bacteria.

For illustration purposes, this change has been tested on a Plants sandbox in place of Bacteria. Here is a screenshot of a Plants gene ZMenu in a Pan Compara tree, with its Protein Summary link in the Bacteria-specific format:
<img width="930" height="512" alt="bacteria_like_protein_summary_link" src="https://github.com/user-attachments/assets/0f27b16e-7914-4489-8306-9789396f2f98" />
