### PR TITLE
Set sample gene-tree action dynamically

### DIFF
--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -26,6 +26,7 @@ use EnsEMBL::Web::Document::HTML::HomeSearch;
 use EnsEMBL::Web::Document::HTML::Compara;
 use EnsEMBL::Web::Component::GenomicAlignments;
 use EnsEMBL::Web::Controller::SSI;
+use EnsEMBL::Web::Utils::Compara qw(get_sample_gene_tree_action);
 
 use LWP::UserAgent;
 use JSON;
@@ -371,12 +372,14 @@ sub _compara_text {
   my $html = '<div class="homepage-icon">';
   
   my $tree_text = $sample_data->{'GENE_TEXT'};
-  my $tree_url  = $species_defs->species_path . '/Gene/Compara_Tree?g=' . $sample_data->{'GENE_PARAM'};
+  my $tree_url;
 
   # EG genetree
+  my $compara_tree_action = EnsEMBL::Web::Utils::Compara::get_sample_gene_tree_action($hub, 'compara');
+  $tree_url  = sprintf('%s/Gene/%s?g=%s', $species_defs->species_path, $compara_tree_action, $sample_data->{'GENE_PARAM'});
   $html .= qq(
     <a class="nodeco _ht" href="$tree_url" title="Go to gene tree for $tree_text"><img src="${img_url}96/compara.png" class="bordered" /><span>Example gene tree</span></a>
-  ) if $self->has_compara('GeneTree');
+  ) if $compara_tree_action;
 
   # EG family
   if ($self->is_bacteria) {
@@ -388,8 +391,9 @@ sub _compara_text {
   #
 
   # EG pan tree
-  $tree_url = $species_defs->species_path . '/Gene/PanComparaTree?g=' . $sample_data->{'GENE_PARAM'};
-  if ($self->has_pan_compara('GeneTree')) {
+  my $pan_compara_tree_action = EnsEMBL::Web::Utils::Compara::get_sample_gene_tree_action($hub, 'compara_pan_ensembl');
+  if ($pan_compara_tree_action) {
+    $tree_url = sprintf('%s/Gene/%s?g=%s', $species_defs->species_path, $pan_compara_tree_action, $sample_data->{'GENE_PARAM'});
     $html .=
       $self->is_bacteria
       ? qq(<a class="nodeco _ht" href="$tree_url" title="Go to pan-taxonomic gene tree for $tree_text"><img src="${img_url}96/compara.png" class="bordered" /><span>Pan-taxonomic tree</span></a>)


### PR DESCRIPTION
## Description

Example gene tree links in Ensembl species homepages are generated using the [Compara_Tree action](https://github.com/Ensembl/ensembl-webcode/blob/a88f841d346aab3b8e59319ab09b40eb36084cc3/modules/EnsEMBL/Web/Component/Info/HomePage.pm#L257) or [PanComparaTree action](https://github.com/EnsemblGenomes/eg-web-common/blob/8c6c5544afc00d8964779ad307f142f9ff279ff8/modules/EnsEMBL/Web/Component/Info/HomePage.pm#L391).

Genomes that are exclusively in a non-default Metazoa gene-tree collections or strain/cultivar gene-tree collections have broken example gene-tree links, because their gene-tree action is not `Compara_Tree` or `PanComparaTree`.

In conjunction with [ensembl-webcode PR 1112](https://github.com/Ensembl/ensembl-webcode/pull/1112), this PR would mend these broken links by calling utility function `EnsEMBL::Web::Utils::Compara::get_sample_gene_tree_action` in the `EnsEMBL::Web::Component::Info::HomePage` to set the example gene-tree action dynamically.

## Views affected

The changes in this PR would be relevant to all species homepages, but these pages should only be affected for genomes that are not in any default gene-tree collection.

An example of such a genome is the Oryza sativa (Xian/Indica-3A var. Lima) cultivar: [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa_lima/Info/Index) vs [live site](https://plants.ensembl.org/Oryza_sativa_lima/Info/Index).

## Related JIRA Issues (EBI developers only)

- ENSWEB-6873