### PR TITLE
Make several small updates to Non-Vertebrate web docs

### DIFF
--- a/htdocs/info/genome/compara/Ortholog_qc_manual.html
+++ b/htdocs/info/genome/compara/Ortholog_qc_manual.html
@@ -55,7 +55,8 @@
     <h2 id="wga">Whole Genome Alignment score</h2>
     <p>
       We assume that genes which are orthologous to each other will fall within genomic regions that can be aligned to one another.
-      Since we calculate pairwise whole genome alignments (WGA), we can use these to check the regions surrounding orthologues.
+      Since we calculate <a href="/info/genome/compara/compara_analyses.html">pairwise whole genome alignments</a> (WGA),
+      we can use these to check the regions surrounding orthologues.
     </p>
 
     <p>
@@ -120,7 +121,8 @@
     <p>
       If GOC or WGA scores are not available or if no threshold is used for a set of orthologues,
       the pipeline will use fallback criteria, that is the prediction will be classified as high
-      confidence if the percentage identity meets the threshold and the prediction is tree compliant.
+      confidence if the percentage identity meets the threshold and the prediction is
+      <a href="/info/genome/compara/homology_types.html#betweenspeciesparalogues">tree compliant</a>.
     </p>
 
   </body>

--- a/htdocs/info/genome/compara/analyses.html
+++ b/htdocs/info/genome/compara/analyses.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <meta name="index" content="DELETE" />
+    <title>Pairwise whole-genome alignments</title>
+  </head>
+  <body>
+    <h1>Genomic alignments</h1>
+    <p>
+    We perform <a href="/info/genome/compara/whole_genome_alignment.html">
+    pairwise whole-genome alignment</a> of selected pairs of genomes.
+    </p>
+    <p>
+    The <a href="/info/genome/compara/compara_analyses.html">list of available
+    pairwise genome alignments</a> includes examples and statistics on each
+    pairwise alignment dataset, as well as any associated synteny data.
+    </p>
+  </body>
+</html>

--- a/htdocs/info/genome/compara/index.html
+++ b/htdocs/info/genome/compara/index.html
@@ -9,25 +9,35 @@
 <h1>Comparative Genomics</h1>
 
 <p>Ensembl Genomes provides cross-genome resources and analyses at both the sequence level and 
-the gene level, using the <a href="https://www.ensembl.org/info/genome/compara/index.html">Ensembl Compara</a> platform. Available analyses include:</p>
+the gene level, using the <a href="https://www.ensembl.org/info/genome/compara/index.html">Ensembl Compara</a> platform.</p>
+
+<p>Available analyses may include the following.</p>
+
+<h2 id="geneanalyses">Gene analyses</h2>
 
 <ul>
-  <li><a href="/info/genome/compara/peptide_compara.html">Peptide comparative genomics</a> 
-providing gene trees and orthology information
-    <ul>
-      <li><a href="/info/genome/compara/prot_tree_stats.html">Statistics on protein trees</a></li>
-    </ul>
+  <li><a href="/info/genome/compara/peptide_compara.html">Peptide comparative genomics</a>
+  providing gene trees and orthology information (see
+  <a href="/info/genome/compara/prot_tree_stats.html">statistics on protein trees</a>)
   </li>
-  <li><a href="/info/genome/compara/whole_genome_alignment.html">Whole genome alignments</a> 
-between selected genomes
-    <ul>
-      <li><a href="/info/genome/compara/compara_analyses.html">Available alignments</a></li>
-    </ul>
+  <li><a href="/info/genome/compara/family_compara.html">Gene families</a>
+  constructed from classification of proteins
   </li>
-  <li><a href="/info/genome/compara/synteny.html">Syntenies</a> calculated from genome or peptide 
-alignments</li>
-  <li><a href="/info/genome/compara/family_compara.html">Gene families</a> constructed from 
-classification of proteins</li>
+</ul>
+
+<h2 id="genomeanalyses">Genome analyses</h2>
+
+<ul>
+  <li><a href="/info/genome/compara/whole_genome_alignment.html">Pairwise whole-genome alignments</a>
+  between selected genomes
+  (see <a href="/info/genome/compara/compara_analyses.html"> available pairwise alignments</a>)
+  </li>
+  <li><a href="/info/genome/compara/multiple_genome_alignments.html">Multiple whole-genome alignments</a>
+  for selected sets of genomes
+  </li>
+  <li><a href="/info/genome/compara/synteny.html">Syntenies</a>
+  calculated from genome or peptide alignments
+  </li>
 </ul>
 
 </body>


### PR DESCRIPTION
This PR would make several small changes to generic Non-Vertebrate web documentation:

#### Align NV Compara index page with Vertebrates Compara index page

This would make it possible, for example, to link to `/info/genome/compara/index.html#genomeanalyses` in all NV sites as well as Ensembl Vertebrates.

- Current Vertebrates index page: https://www.ensembl.org/info/genome/compara/index.html
- Current Non-Vertebrates Compara index page: https://metazoa.ensembl.org/info/genome/compara/index.html
- Proposed Non-Vertebrates Compara index page: http://wp-np2-35.ebi.ac.uk:5094/info/genome/compara/index.html

#### Add pairwise whole-genome alignment navigation page

This would make it possible to link to `/info/genome/compara/analyses.html` in all NV sites as well as Ensembl Vertebrates.

- Sandbox: http://wp-np2-35.ebi.ac.uk:5094/info/genome/compara/analyses.html
- Live site: https://metazoa.ensembl.org/info/genome/compara/analyses.html

#### Restore links to generic NV ortholog QC manual

It's possible to restore these links in large part as a result of recent NV documentation updates.

- Sandbox: http://wp-np2-35.ebi.ac.uk:5094/info/genome/compara/Ortholog_qc_manual.html
- Live site: https://metazoa.ensembl.org/info/genome/compara/Ortholog_qc_manual.html