### PR TITLE
Update pan_compara_species files for eg63/e116

### DIFF
--- a/htdocs/ssi/species/pan_compara_species.html
+++ b/htdocs/ssi/species/pan_compara_species.html
@@ -3,288 +3,296 @@
 <td colspan="3" style="width:50%;padding:2px;padding-bottom:1em">&nbsp;</td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/acinetobacter_baumannii_aye/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Acinetobacter baumannii AYE</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/gallus_gallus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Gallus gallus</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/physcomitrella_patens/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Physcomitrella patens subsp. patens</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Acinetobacter_baumannii_aye_gca_000069245/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Acinetobacter baumannii AYE (GCA_000069245)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Actinobacillus_pleuropneumoniae_serovar_5b_str_l20_gca_000015885/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Actinobacillus pleuropneumoniae serovar 5b str. L20 (GCA_000015885)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Aedes_aegypti_lvpagwg/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aedes aegypti (Yellow fever mosquito, LVP_AGWG)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/actinobacillus_pleuropneumoniae_serovar_5b_str_l20/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Actinobacillus pleuropneumoniae serovar 5b str. L20</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/gardnerella_vaginalis_0288e/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Gardnerella vaginalis 0288E</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/phytophthora_infestans/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Phytophthora infestans T30-4</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Aeromonas_hydrophila_subsp_hydrophila_atcc_7966_gca_000014805/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aeromonas hydrophila subsp. hydrophila ATCC 7966 (GCA_000014805)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Aeropyrum_pernix_k1_gca_000011125/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aeropyrum pernix K1 (GCA_000011125)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Agrobacterium_fabrum_str_c58_gca_000092025/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Agrobacterium fabrum str. C58 (GCA_000092025)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/aeromonas_hydrophila_subsp_hydrophila_atcc_7966/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aeromonas hydrophila subsp. hydrophila ATCC 7966</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/gasterosteus_aculeatus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Gasterosteus aculeatus</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/plasmodium_falciparum/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Plasmodium falciparum 3D7</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Aliivibrio_fischeri_es114_gca_000011805/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aliivibrio fischeri ES114 (GCA_000011805)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Amborella_trichopoda/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Amborella trichopoda</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Amphimedon_queenslandica_gca000090795v2rs/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Amphimedon queenslandica (Demosponge)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/aeropyrum_pernix_k1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aeropyrum pernix K1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/geobacter_sulfurreducens_pca/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Geobacter sulfurreducens PCA</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/pongo_abelii/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pongo abelii</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Anaplasma_phagocytophilum_str_hz_gca_000013125/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Anaplasma phagocytophilum str. HZ (GCA_000013125)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Anopheles_gambiae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Anopheles gambiae (African malaria mosquito, PEST) - GCA_000005575.1</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Apis_mellifera/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Apis mellifera (Honey bee, DH4)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/aggregatibacter_actinomycetemcomitans_d11s_1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aggregatibacter actinomycetemcomitans D11S-1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/giardia_lamblia/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Giardia lamblia ATCC 50803</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/porphyromonas_gingivalis_w83/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Porphyromonas gingivalis W83</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Aquifex_aeolicus_vf5_gca_000008625/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aquifex aeolicus VF5 (GCA_000008625)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Arabidopsis_thaliana/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Arabidopsis thaliana</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Archaeoglobus_fulgidus_dsm_4304_gca_000008665/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Archaeoglobus fulgidus DSM 4304 (GCA_000008665)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/agrobacterium_fabrum_str_c58/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Agrobacterium fabrum str. C58</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/gloeobacter_violaceus_pcc_7421/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Gloeobacter violaceus PCC 7421</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/prevotella_intermedia_17/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Prevotella intermedia 17</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/Aspergillus_nidulans/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aspergillus nidulans</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Azotobacter_vinelandii_dj_gca_000021045/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Azotobacter vinelandii DJ (GCA_000021045)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Bacillus_subtilis_subsp_subtilis_str_168_gca_000009045/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bacillus subtilis subsp. subtilis str. 168 (GCA_000009045)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/amphimedon_queenslandica/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Amphimedon queenslandica</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/guillardia_theta/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Guillardia theta CCMP2712</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/prochlorococcus_marinus_subsp_marinus_str_ccmp1375/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Prochlorococcus marinus subsp. marinus str. CCMP1375</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Bacteroides_thetaiotaomicron_vpi_5482_gca_000011065/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bacteroides thetaiotaomicron VPI-5482 (GCA_000011065)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Bartonella_henselae_str_houston_1_gca_000046705/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bartonella henselae str. Houston-1 (GCA_000046705)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Bifidobacterium_longum_ncc2705_gca_000007525/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bifidobacterium longum NCC2705 (GCA_000007525)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/anaplasma_phagocytophilum_hz/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Anaplasma phagocytophilum HZ</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/haemophilus_influenzae_rd_kw20/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Haemophilus influenzae Rd KW20</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/propionibacterium_acnes_kpa171202/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Propionibacterium acnes KPA171202</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Bigelowiella_natans/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bigelowiella natans</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Borreliella_burgdorferi_b31_gca_000008685/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Borreliella burgdorferi B31 (GCA_000008685)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Brachypodium_distachyon/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Brachypodium distachyon</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/anolis_carolinensis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Anolis carolinensis</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/haloarcula_marismortui_atcc_43049/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Haloarcula marismortui ATCC 43049</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/proteus_mirabilis_hi4320/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Proteus mirabilis HI4320</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Bradyrhizobium_diazoefficiens_usda_110_gca_000011365/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bradyrhizobium diazoefficiens USDA 110 (GCA_000011365)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Brucella_abortus_bv_1_str_9_941_gca_000008145/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Brucella abortus bv. 1 str. 9-941 (GCA_000008145)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Brugia_malayi_prjna10729/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Brugia malayi (Nematode, FR3)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/anopheles_gambiae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Anopheles gambiae</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/halobacterium_salinarum_r1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Halobacterium salinarum R1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/pseudomonas_aeruginosa_mpao1_p2/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pseudomonas aeruginosa MPAO1/P2</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Buchnera_aphidicola_str_aps_acyrthosiphon_pisum__gca_000009605/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Buchnera aphidicola str. APS (Acyrthosiphon pisum) (GCA_000009605)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Burkholderia_pseudomallei_1710b_gca_000012785/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Burkholderia pseudomallei 1710b (GCA_000012785)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Ciona_savignyi/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">C.savignyi</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/apis_mellifera/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Apis mellifera</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/haloferax_volcanii_ds2_asm2568v1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Haloferax volcanii DS2</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/puccinia_graminis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Puccinia graminis f. sp. tritici CRL 75-36-700-3</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Caenorhabditis_elegans/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Caenorhabditis elegans (Nematode, N2)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Campylobacter_jejuni_subsp_jejuni_nctc_11168_atcc_700819_gca_000009085/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Campylobacter jejuni subsp. jejuni NCTC 11168 = ATCC 700819 (GCA_000009085)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Candidatus_korarchaeum_cryptofilum_opf8_gca_000019605/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Candidatus Korarchaeum cryptofilum OPF8 (GCA_000019605)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/aquifex_aeolicus_vf5/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aquifex aeolicus VF5</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/helicobacter_pylori_26695_asm852v1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Helicobacter pylori 26695</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/pyrobaculum_aerophilum_str_im2/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pyrobaculum aerophilum str. IM2</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Candidatus_koribacter_versatilis_ellin345_gca_000014005/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Candidatus Koribacter versatilis Ellin345 (GCA_000014005)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Caulobacter_vibrioides_cb15_gca_000006905/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Caulobacter vibrioides CB15 (GCA_000006905)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Cenarchaeum_symbiosum_a_gca_000200715/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Cenarchaeum symbiosum A (GCA_000200715)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/arabidopsis_thaliana/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Arabidopsis thaliana</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/helobdella_robusta/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Helobdella robusta</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/pyrococcus_horikoshii_ot3/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pyrococcus horikoshii OT3</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Gallus_gallus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chicken</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Pan_troglodytes/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chimpanzee</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Chlamydia_trachomatis_d_uw_3_cx_gca_000008725/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chlamydia trachomatis D/UW-3/CX (GCA_000008725)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/archaeoglobus_fulgidus_dsm_4304/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Archaeoglobus fulgidus DSM 4304</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/homo_sapiens/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Homo sapiens</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/ralstonia_solanacearum_gmi1000/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Ralstonia solanacearum GMI1000</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Chlamydomonas_reinhardtii/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chlamydomonas reinhardtii</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Chlorobaculum_tepidum_tls_gca_000006985/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chlorobaculum tepidum TLS (GCA_000006985)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Chloroflexus_aurantiacus_j_10_fl_gca_000018865/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chloroflexus aurantiacus J-10-fl (GCA_000018865)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/aspergillus_nidulans/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Aspergillus nidulans FGSC A4</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/hyperthermus_butylicus_dsm_5456/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Hyperthermus butylicus DSM 5456</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/rhizobium_leguminosarum_bv_viciae_3841/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhizobium leguminosarum bv. viciae 3841</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Clostridioides_difficile_630_gca_000009205/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Clostridioides difficile 630 (GCA_000009205)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Coxiella_burnetii_rsa_493_gca_000007765/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Coxiella burnetii RSA 493 (GCA_000007765)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Cryptomonas_paramecium_gca_000194455/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Cryptomonas paramecium str. CCAP977/2A (GCA_000194455.1)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/azotobacter_vinelandii_dj/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Azotobacter vinelandii DJ</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/klebsiella_pneumoniae_subsp_pneumoniae_mgh_78578/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Klebsiella pneumoniae subsp. pneumoniae MGH 78578</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/rhodobacter_sphaeroides_2_4_1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhodobacter sphaeroides 2.4.1</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Cutibacterium_acnes_kpa171202_gca_000008345/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Cutibacterium acnes KPA171202 (GCA_000008345)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Cyanidioschyzon_merolae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Cyanidioschyzon merolae</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Daphnia_pulex_gca021134715v1rs/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Daphnia pulex (Common water flea, KAP4)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/bacillus_subtilis_subsp_subtilis_str_168/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bacillus subtilis subsp. subtilis str. 168</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/lactobacillus_plantarum_wcfs1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lactobacillus plantarum WCFS1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/rhodopirellula_baltica_sh_1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhodopirellula baltica SH 1</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Deinococcus_radiodurans_r1_gca_000008565/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Deinococcus radiodurans R1 (GCA_000008565)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Desulfovibrio_vulgaris_str_hildenborough_gca_000195755/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Desulfovibrio vulgaris str. Hildenborough (GCA_000195755)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Dictyoglomus_turgidum_dsm_6724_gca_000021645/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Dictyoglomus turgidum DSM 6724 (GCA_000021645)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/bacteroides_thetaiotaomicron_vpi_5482/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bacteroides thetaiotaomicron VPI-5482</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/lactococcus_lactis_subsp_lactis_il1403/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lactococcus lactis subsp. lactis Il1403</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/rhodospirillum_rubrum_atcc_11170/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhodospirillum rubrum ATCC 11170</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Dictyostelium_discoideum/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Dictyostelium discoideum</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Drosophila_melanogaster/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Drosophila melanogaster - (Fruit fly)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Emiliania_huxleyi/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Emiliania huxleyi</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/bartonella_henselae_str_houston_1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bartonella henselae str. Houston-1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/legionella_pneumophila_str_paris/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Legionella pneumophila str. Paris</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/rickettsia_prowazekii_str_madrid_e/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rickettsia prowazekii str. Madrid E</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Enterobacter_cloacae_subsp_cloacae_atcc_13047_gca_000025565/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Enterobacter cloacae subsp. cloacae ATCC 13047 (GCA_000025565)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Enterococcus_faecalis_v583_gca_000007785/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Enterococcus faecalis V583 (GCA_000007785)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Escherichia_coli_str_k_12_substr_mg1655_gca_000005845/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Escherichia coli str. K-12 substr. MG1655 str. K12 (GCA_000005845)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/bifidobacterium_longum_ncc2705/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bifidobacterium longum NCC2705</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/leishmania_major/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Leishmania major strain Friedlin</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/saccharomyces_cerevisiae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Saccharomyces cerevisiae S288c</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Flavobacterium_psychrophilum_jip02_86_gca_000064305/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Flavobacterium psychrophilum JIP02/86 (GCA_000064305)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Francisella_tularensis_subsp_tularensis_schu_s4_gca_000008985/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Francisella tularensis subsp. tularensis SCHU S4 str. Schu S4 (GCA_000008985)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Fusobacterium_nucleatum_subsp_nucleatum_atcc_25586_gca_000007325/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Fusobacterium nucleatum subsp. nucleatum ATCC 25586 (GCA_000007325)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/bordetella_pertussis_tohama_i/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bordetella pertussis Tohama I</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/leptospira_interrogans_serovar_lai_str_56601/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Leptospira interrogans serovar Lai str. 56601</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/salinibacter_ruber_dsm_13855/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Salinibacter ruber DSM 13855</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Gardnerella_vaginalis_0288e_gca_000263555/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Gardnerella vaginalis 0288E (GCA_000263555)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Geobacter_sulfurreducens_pca_gca_000007985/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Geobacter sulfurreducens PCA (GCA_000007985)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Giardia_intestinalis_gca000002435v2/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Giardia intestinalis - GCA_000002435.2</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/borrelia_burgdorferi_b31/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Borrelia burgdorferi B31</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/leuconostoc_mesenteroides_subsp_mesenteroides_atcc_8293/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Leuconostoc mesenteroides subsp. mesenteroides ATCC 8293</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/salmonella_enterica_subsp_enterica_serovar_typhimurium_str_lt2/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Salmonella enterica subsp. enterica serovar Typhimurium str. LT2</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Gigantopelta_aegis_gca016097555v1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Gigantopelta aegis (Deep sea snail, Gae_Host)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Gloeobacter_violaceus_pcc_7421_gca_000011385/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Gloeobacter violaceus PCC 7421 (GCA_000011385)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Anolis_carolinensis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Green anole</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/bradyrhizobium_japonicum_usda_110/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Bradyrhizobium japonicum USDA 110</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/listeria_monocytogenes_egd_e/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Listeria monocytogenes EGD-e</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/schistosoma_mansoni/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Schistosoma mansoni</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Guillardia_theta/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Guillardia theta CCMP2712</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Haemophilus_influenzae_rd_kw20_gca_000027305/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Haemophilus influenzae Rd KW20 (GCA_000027305)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Haloarcula_marismortui_atcc_43049_gca_000011085/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Haloarcula marismortui ATCC 43049 (GCA_000011085)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/brucella_abortus_bv_1_str_9_941/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Brucella abortus bv. 1 str. 9-941</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/lottia_gigantea/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lottia gigantea</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/schizosaccharomyces_pombe/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Schizosaccharomyces pombe 972h-</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Halobacterium_salinarum_r1_gca_000069025/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Halobacterium salinarum R1 (GCA_000069025)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Haloferax_volcanii_ds2_gca_000025685/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Haloferax volcanii DS2 (GCA_000025685)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Helicobacter_pylori_26695_gca_000008525/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Helicobacter pylori 26695 (GCA_000008525)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/brugia_malayi/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Brugia malayi</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/lysinibacillus_sphaericus_c3_41/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lysinibacillus sphaericus C3-41</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/shewanella_oneidensis_mr_1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Shewanella oneidensis MR-1</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Heliconius_melpomene/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Heliconius melpomene (Postman butterfly)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Helobdella_robusta/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Helobdella robusta (Freshwater leech)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Homo_sapiens/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Human</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/buchnera_aphidicola_str_aps_acyrthosiphon_pisum_/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Buchnera aphidicola str. APS (Acyrthosiphon pisum)</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/mannheimia_haemolytica_serotype_a2_str_ovine/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mannheimia haemolytica serotype A2 str. OVINE</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/shigella_dysenteriae_sd197/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Shigella dysenteriae Sd197</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Hydra_vulgaris_gca038396675v1rs/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Hydra vulgaris (Swiftwater hydra)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Hyperthermus_butylicus_dsm_5456_gca_000015145/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Hyperthermus butylicus DSM 5456 (GCA_000015145)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Klebsiella_pneumoniae_subsp_pneumoniae_mgh_78578_gca_000016305/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Klebsiella pneumoniae subsp. pneumoniae MGH 78578 (GCA_000016305)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/burkholderia_pseudomallei_1710b/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Burkholderia pseudomallei 1710b</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/mesoplasma_florum_l1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mesoplasma florum L1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/sinorhizobium_meliloti_1021/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Sinorhizobium meliloti 1021</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Lactobacillus_plantarum_wcfs1_gca_000203855/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lactobacillus plantarum WCFS1 (GCA_000203855)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Lactococcus_lactis_subsp_lactis_il1403_gca_000006865/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lactococcus lactis subsp. lactis Il1403 (GCA_000006865)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Leishmania_major/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Leishmania major</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/caenorhabditis_elegans/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Caenorhabditis elegans</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanobacterium_formicicum_dsm_3637/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanobacterium formicicum DSM 3637</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/solanum_lycopersicum/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Solanum lycopersicum</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Leptospira_interrogans_serovar_lai_str_56601_gca_000092565/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Leptospira interrogans serovar Lai str. 56601 (GCA_000092565)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Leuconostoc_mesenteroides_subsp_mesenteroides_atcc_8293_gca_000014445/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Leuconostoc mesenteroides subsp. mesenteroides ATCC 8293 (GCA_000014445)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Lingula_anatina_gca001039355v2/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lingula anatina (Lamp shell, Amm_Jpn)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/campylobacter_jejuni_subsp_jejuni_nctc_11168_atcc_700819/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Campylobacter jejuni subsp. jejuni NCTC 11168 = ATCC 700819</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanobrevibacter_smithii_atcc_35061/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanobrevibacter smithii ATCC 35061</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/staphylococcus_aureus_subsp_aureus_n315/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Staphylococcus aureus subsp. aureus N315</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Listeria_monocytogenes_egd_e_gca_000196035/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Listeria monocytogenes EGD-e (GCA_000196035)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Lysinibacillus_sphaericus_c3_41_gca_000017965/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lysinibacillus sphaericus C3-41 (GCA_000017965)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Lytechinus_variegatus_gca018143015v1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Lytechinus variegatus (Green sea urchin, NC3)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/candidatus_korarchaeum_cryptofilum_opf8/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Candidatus Korarchaeum cryptofilum OPF8</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanocaldococcus_jannaschii_dsm_2661/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanocaldococcus jannaschii DSM 2661</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/stenotrophomonas_maltophilia_k279a/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Stenotrophomonas maltophilia K279a</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Marchantia_polymorpha/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Marchantia polymorpha</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Mesoplasma_florum_l1_gca_000008305/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mesoplasma florum L1 (GCA_000008305)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Methanobrevibacter_smithii_atcc_35061_gca_000016525/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanobrevibacter smithii ATCC 35061 (GCA_000016525)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/candidatus_koribacter_versatilis_ellin345/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Candidatus Koribacter versatilis Ellin345</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanococcus_maripaludis_s2/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanococcus maripaludis S2</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/streptococcus_pneumoniae_tigr4/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Streptococcus pneumoniae TIGR4</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Methanocaldococcus_jannaschii_dsm_2661_gca_000091665/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanocaldococcus jannaschii DSM 2661 (GCA_000091665)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Methanococcus_maripaludis_s2_gca_000011585/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanococcus maripaludis S2 (GCA_000011585)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Methanopyrus_kandleri_av19_gca_000007185/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanopyrus kandleri AV19 (GCA_000007185)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/caulobacter_crescentus_cb15/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Caulobacter crescentus CB15</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanopyrus_kandleri_av19/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanopyrus kandleri AV19</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/streptomyces_coelicolor_a3_2_/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Streptomyces coelicolor A3(2)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Methanosarcina_acetivorans_c2a_gca_000007345/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanosarcina acetivorans C2A (GCA_000007345)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Methanospirillum_hungatei_jf_1_gca_000013445/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanospirillum hungatei JF-1 (GCA_000013445)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Methanothermobacter_thermautotrophicus_str_delta_h_gca_000008645/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanothermobacter thermautotrophicus str. Delta H (GCA_000008645)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/cenarchaeum_symbiosum_a/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Cenarchaeum symbiosum A</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanosarcina_acetivorans_c2a/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanosarcina acetivorans C2A</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/strigamia_maritima/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Strigamia maritima</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Micrococcus_luteus_nctc_2665_gca_000023205/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Micrococcus luteus NCTC 2665 (GCA_000023205)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Microcystis_aeruginosa_nies_843_gca_000010625/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Microcystis aeruginosa NIES-843 (GCA_000010625)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Mnemiopsis_leidyi/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mnemiopsis leidyi (Warty comb jelly)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/chlamydia_trachomatis_d_uw_3_cx/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chlamydia trachomatis D/UW-3/CX</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanospirillum_hungatei_jf_1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanospirillum hungatei JF-1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/strongylocentrotus_purpuratus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Strongylocentrotus purpuratus</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Monosiga_brevicollis_mx1_gca_000002865/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Monosiga brevicollis MX1 (GCA_000002865.1)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Moorella_thermoacetica_atcc_39073_gca_000013105/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Moorella thermoacetica ATCC 39073 (GCA_000013105)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Mus_musculus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mouse</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/chlamydomonas_reinhardtii/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chlamydomonas reinhardtii</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/methanothermobacter_thermautotrophicus_str_delta_h/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Methanothermobacter thermautotrophicus str. Delta H</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/sulfolobus_solfataricus_p2/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Sulfolobus solfataricus P2</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Mycoplasma_pneumoniae_m129_gca_000027345/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mycoplasma pneumoniae M129 (GCA_000027345)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/Ustilago_maydis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mycosarcoma maydis</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Myxococcus_xanthus_dk_1622_gca_000012685/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Myxococcus xanthus DK 1622 (GCA_000012685)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/chlorobium_tepidum_tls/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chlorobium tepidum TLS</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/micrococcus_luteus_nctc_2665/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Micrococcus luteus NCTC 2665</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/synechocystis_sp_pcc_6803_asm972v1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Synechocystis sp. PCC 6803</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Nanoarchaeum_equitans_kin4_m_gca_000008085/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Nanoarchaeum equitans Kin4-M (GCA_000008085)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Natronomonas_pharaonis_dsm_2160_gca_000026045/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Natronomonas pharaonis DSM 2160 (GCA_000026045)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Neisseria_meningitidis_z2491_gca_000009105/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Neisseria meningitidis Z2491 (GCA_000009105)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/chloroflexus_aurantiacus_j_10_fl/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Chloroflexus aurantiacus J-10-fl</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/microcystis_aeruginosa_nies_843/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Microcystis aeruginosa NIES-843</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/tetrahymena_thermophila/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Tetrahymena thermophila SB210</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/Neurospora_crassa/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Neurospora crassa</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Nitrosopumilus_maritimus_scm1_gca_000018465/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Nitrosopumilus maritimus SCM1 (GCA_000018465)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Nostoc_punctiforme_pcc_73102_gca_000020025/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Nostoc punctiforme PCC 73102 (GCA_000020025)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/ciona_savignyi/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Ciona savignyi</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/monodelphis_domestica/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Monodelphis domestica</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/tetranychus_urticae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Tetranychus urticae</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Octopus_bimaculoides_gca001194135v2rs/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Octopus bimaculoides (California two-spot octopus, UCB-OBI-ISO-001)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Monodelphis_domestica/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Opossum</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Oryza_sativa/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Oryza sativa Japonica Group</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Citrobacter freundii 4_7_47CFAA</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/moorella_thermoacetica_atcc_39073/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Moorella thermoacetica ATCC 39073</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermanaerovibrio_acidaminovorans_dsm_6589/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermanaerovibrio acidaminovorans DSM 6589</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Paracoccus_denitrificans_pd1222_gca_000203895/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Paracoccus denitrificans PD1222 (GCA_000203895)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Parasteatoda_tepidariorum_GCA_043381705.1rs/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Parasteatoda tepidariorum (Common house spider, YZ-2023)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Pasteurella_multocida_subsp_multocida_str_pm70_gca_000006825/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pasteurella multocida subsp. multocida str. Pm70 (GCA_000006825)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/clostridium_botulinum_a_str_hall/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Clostridium botulinum A str. Hall</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/moraxella_catarrhalis_7169/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Moraxella catarrhalis 7169</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermococcus_kodakarensis_kod1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermococcus kodakarensis KOD1</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Pediculus_humanus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pediculus humanus corporis (Human body louse, USDA)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Phaeodactylum_tricornutum/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Phaeodactylum tricornutum</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Physcomitrium_patens/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Physcomitrium patens</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/clostridium_difficile_630/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Clostridium difficile 630</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/mus_musculus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mus musculus</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermodesulfovibrio_yellowstonii_dsm_11347/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermodesulfovibrio yellowstonii DSM 11347</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Phytophthora_infestans/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Phytophthora infestans</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Plasmodium_falciparum/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Plasmodium falciparum - GCA_000002765.3</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Ornithorhynchus_anatinus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Platypus</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/corynebacterium_glutamicum_atcc_13032_asm19633v1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Corynebacterium glutamicum ATCC 13032</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mycobacterium tuberculosis H37Rv</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermofilum_pendens_hrk_5/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermofilum pendens Hrk 5</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Porphyromonas_gingivalis_w83_gca_000007585/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Porphyromonas gingivalis W83 (GCA_000007585)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Prochlorococcus_marinus_subsp_marinus_str_ccmp1375_gca_000007925/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Prochlorococcus marinus subsp. marinus str. CCMP1375 (GCA_000007925)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Proteus_mirabilis_hi4320_gca_000069965/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Proteus mirabilis HI4320 (GCA_000069965)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/coxiella_burnetii_rsa_493/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Coxiella burnetii RSA 493</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/mycoplasma_pneumoniae_m129/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Mycoplasma pneumoniae M129</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermoplasma_acidophilum_dsm_1728/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermoplasma acidophilum DSM 1728</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/Puccinia_graminis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Puccinia graminis</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Pyrobaculum_aerophilum_str_im2_gca_000007225/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pyrobaculum aerophilum str. IM2 (GCA_000007225)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Pyrococcus_horikoshii_ot3_gca_000011105/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pyrococcus horikoshii OT3 (GCA_000011105)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/cyanidioschyzon_merolae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Cyanidioschyzon merolae strain 10D</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/myxococcus_xanthus_dk_1622/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Myxococcus xanthus DK 1622</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermosynechococcus_elongatus_bp_1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermosynechococcus elongatus BP-1</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Ralstonia_solanacearum_gmi1000_gca_000009125/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Ralstonia solanacearum GMI1000 (GCA_000009125)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Rhizobium_leguminosarum_bv_viciae_3841_gca_000009265/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhizobium leguminosarum bv. viciae 3841 (GCA_000009265)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Rhodobacter_sphaeroides_2_4_1_gca_000012905/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhodobacter sphaeroides 2.4.1 (GCA_000012905)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/danio_rerio/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Danio rerio</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/nanoarchaeum_equitans_kin4_m/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Nanoarchaeum equitans Kin4-M</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermotoga_maritima_msb8_asm854v1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermotoga maritima MSB8</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Rhodopirellula_baltica_sh_1_gca_000196115/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhodopirellula baltica SH 1 (GCA_000196115)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Rhodospirillum_rubrum_atcc_11170_gca_000013085/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rhodospirillum rubrum ATCC 11170 (GCA_000013085)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Rickettsia_prowazekii_str_madrid_e_gca_000195735/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Rickettsia prowazekii str. Madrid E (GCA_000195735)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/daphnia_pulex/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Daphnia pulex</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/natronomonas_pharaonis_dsm_2160/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Natronomonas pharaonis DSM 2160</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/thermus_thermophilus_hb8/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermus thermophilus HB8</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Saccharolobus_solfataricus_p2_gca_000007005/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Saccharolobus solfataricus P2 (GCA_000007005)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/Saccharomyces_cerevisiae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Saccharomyces cerevisiae</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Salinibacter_ruber_dsm_13855_gca_000013045/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Salinibacter ruber DSM 13855 (GCA_000013045)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/deinococcus_radiodurans_r1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Deinococcus radiodurans R1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/neisseria_meningitidis_z2491/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Neisseria meningitidis Z2491</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/treponema_pallidum_subsp_pallidum_str_nichols/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Treponema pallidum subsp. pallidum str. Nichols</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Schistosoma_mansoni_prjea36577/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Schistosoma mansoni (Flatworm)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/Schizosaccharomyces_pombe/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Schizosaccharomyces pombe</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Selaginella_moellendorffii/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Selaginella moellendorffii</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/desulfovibrio_vulgaris_str_hildenborough/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Desulfovibrio vulgaris str. Hildenborough</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/nematostella_vectensis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Nematostella vectensis</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/trichoplax_adhaerens/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Trichoplax adhaerens</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Shigella_dysenteriae_sd197_gca_000012005/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Shigella dysenteriae Sd197 (GCA_000012005)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Sinorhizobium_meliloti_1021_gca_000006965/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Sinorhizobium meliloti 1021 (GCA_000006965)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Solanum_lycopersicum_GCA_000188115.5cm/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Solanum lycopersicum Heinz1706</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/dictyoglomus_turgidum_dsm_6724/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Dictyoglomus turgidum DSM 6724</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/neurospora_crassa/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Neurospora crassa OR74A</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/ureaplasma_parvum_serovar_3_str_atcc_700970/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Ureaplasma parvum serovar 3 str. ATCC 700970</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Staphylococcus_aureus_subsp_aureus_n315_gca_000009645/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Staphylococcus aureus subsp. aureus N315 (GCA_000009645)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Stenotrophomonas_maltophilia_k279a_gca_000072485/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Stenotrophomonas maltophilia K279a (GCA_000072485)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Gasterosteus_aculeatus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Stickleback</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/dictyostelium_discoideum/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Dictyostelium discoideum</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/nitrosopumilus_maritimus_scm1/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Nitrosopumilus maritimus SCM1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/ustilago_maydis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Ustilago maydis 521</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Streptococcus_pneumoniae_tigr4_gca_000006885/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Streptococcus pneumoniae TIGR4 (GCA_000006885)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Strigamia_maritima/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Strigamia maritima (Soil centipede)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Pongo_abelii/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Sumatran orangutan</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/drosophila_melanogaster/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Drosophila melanogaster</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/nostoc_punctiforme_pcc_73102/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Nostoc punctiforme PCC 73102</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/vibrio_cholerae_o1_biovar_el_tor_str_n16961/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Vibrio cholerae O1 biovar El Tor str. N16961</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Synechocystis_sp_pcc_6803_gca_000009725/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Synechocystis sp. PCC 6803 (GCA_000009725)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Tetrahymena_thermophila/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Tetrahymena thermophila</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Tetranychus_urticae/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Tetranychus urticae (Two-spotted spider mite)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/enterobacter_cloacae_subsp_cloacae_atcc_13047/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Enterobacter cloacae subsp. cloacae ATCC 13047</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/ornithorhynchus_anatinus/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Ornithorhynchus anatinus</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/vibrio_fischeri_es114/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Vibrio fischeri ES114</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/Thecamonas_trahens_atcc_50062_gca_000142905/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thecamonas trahens ATCC 50062 (GCA_000142905.1)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermanaerovibrio_acidaminovorans_dsm_6589_gca_000024905/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermanaerovibrio acidaminovorans DSM 6589 (GCA_000024905)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermococcus_kodakarensis_kod1_gca_000009965/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermococcus kodakarensis KOD1 (GCA_000009965)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/enterococcus_faecalis_v583/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Enterococcus faecalis V583</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/oryza_sativa/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Oryza sativa Japonica Group</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/vitis_vinifera/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Vitis vinifera</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermodesulfovibrio_yellowstonii_dsm_11347_gca_000020985/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermodesulfovibrio yellowstonii DSM 11347 (GCA_000020985)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermofilum_pendens_hrk_5_gca_000015225/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermofilum pendens Hrk 5 (GCA_000015225)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermoplasma_acidophilum_dsm_1728_gca_000195915/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermoplasma acidophilum DSM 1728 (GCA_000195915)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/escherichia_coli_str_k_12_substr_mg1655/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Escherichia coli str. K-12 substr. MG1655</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/pan_troglodytes/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pan troglodytes</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/wolbachia_endosymbiont_of_drosophila_melanogaster/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Wolbachia endosymbiont of Drosophila melanogaster</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermosynechococcus_elongatus_bp_1_gca_000011345/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermosynechococcus elongatus BP-1 (GCA_000011345)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermotoga_maritima_msb8_gca_000008545/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermotoga maritima MSB8 (GCA_000008545)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Thermus_thermophilus_hb8_gca_000091545/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Thermus thermophilus HB8 (GCA_000091545)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/flavobacterium_psychrophilum_jip02_86/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Flavobacterium psychrophilum JIP02/86</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/paracoccus_denitrificans_pd1222/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Paracoccus denitrificans PD1222</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/xanthomonas_campestris_pv_campestris_str_atcc_33913/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Xanthomonas campestris pv. campestris str. ATCC 33913</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Treponema_pallidum_subsp_pallidum_str_nichols_gca_000008605/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Treponema pallidum subsp. pallidum str. Nichols (GCA_000008605)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Tribolium_castaneum_gca031307605v1rs/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Tribolium castaneum (Red flour beetle, GA2)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Trichoplax_adhaerens/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Trichoplax adhaerens (Placozoa, Grell-BS-1999)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/francisella_tularensis_subsp_tularensis_schu_s4/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Francisella tularensis subsp. tularensis SCHU S4</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/pasteurella_multocida_subsp_multocida_str_pm70/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Pasteurella multocida subsp. multocida str. Pm70</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/xenopus_tropicalis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Xenopus tropicalis</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Xenopus_tropicalis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Tropical clawed frog</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Ureaplasma_parvum_serovar_3_str_atcc_700970_gca_000006625/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Ureaplasma parvum serovar 3 str. ATCC 700970 (GCA_000006625)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Vibrio_cholerae_o1_biovar_el_tor_str_n16961_gca_000006745/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Vibrio cholerae O1 biovar El Tor str. N16961 (GCA_000006745)</a></td>
 </tr>
 <tr>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/fusobacterium_nucleatum_subsp_nucleatum_atcc_25586/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Fusobacterium nucleatum subsp. nucleatum ATCC 25586</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://protists.ensembl.org/phaeodactylum_tricornutum/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Phaeodactylum tricornutum CCAP 1055/1</a></td>
-<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/yersinia_pestis_biovar_microtus_str_91001/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Yersinia pestis biovar Microtus str. 91001</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://plants.ensembl.org/Vitis_vinifera/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Vitis vinifera</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Wolbachia_endosymbiont_of_drosophila_melanogaster_gca_000008025/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Wolbachia endosymbiont of Drosophila melanogaster (GCA_000008025)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Xanthomonas_campestris_pv_campestris_str_atcc_33913_gca_000007145/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Xanthomonas campestris pv. campestris str. ATCC 33913 (GCA_000007145)</a></td>
+</tr>
+<tr>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://bacteria.ensembl.org/Yersinia_pestis_biovar_microtus_str_91001_gca_000007885/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Yersinia pestis biovar Microtus str. 91001 (GCA_000007885)</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://www.ensembl.org/Danio_rerio/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Zebrafish</a></td>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://metazoa.ensembl.org/Zootermopsis_nevadensis/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Zootermopsis nevadensis (Nevada dampwood termite)</a></td>
+</tr>
+<tr>
+<td style="width:8%;text-align:left;padding-bottom:1em"><a href="https://fungi.ensembl.org/Zymoseptoria_tritici/Info/Index/" rel="external" style="font-size:1.1em;font-weight:bold;text-decoration:none;">Zymoseptoria tritici</a></td>
 </tr>
 </table>

--- a/htdocs/ssi/species/pan_compara_species.xml
+++ b/htdocs/ssi/species/pan_compara_species.xml
@@ -1226,4 +1226,3 @@
     <Published>Yes</Published>
   </node>
 </nodes>
-</nodes>

--- a/htdocs/ssi/species/pan_compara_species.xml
+++ b/htdocs/ssi/species/pan_compara_species.xml
@@ -1,45 +1,94 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <nodes>
   <node>
-    <name>Treponema pallidum subsp. pallidum str. Nichols (ASM860v1)</name>
+    <name>Acinetobacter baumannii AYE (GCA_000069245)</name>
     <division>Bacteria</division>
-    <taxonomy>243276</taxonomy>
-    <db_name>treponema_pallidum_subsp_pallidum_str_nichols_asm860v1</db_name>
+    <taxonomy>509173</taxonomy>
+    <db_name>acinetobacter_baumannii_aye_gca_000069245</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Haloferax volcanii DS2 (ASM2568v1)</name>
+    <name>Actinobacillus pleuropneumoniae serovar 5b str. L20 (GCA_000015885)</name>
     <division>Bacteria</division>
-    <taxonomy>309800</taxonomy>
-    <db_name>haloferax_volcanii_ds2_asm2568v1</db_name>
+    <taxonomy>416269</taxonomy>
+    <db_name>actinobacillus_pleuropneumoniae_serovar_5b_str_l20_gca_000015885</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Enterococcus faecalis V583 (ASM778v1)</name>
-    <division>Bacteria</division>
-    <taxonomy>226185</taxonomy>
-    <db_name>enterococcus_faecalis_v583_asm778v1</db_name>
+    <name>Aedes aegypti (Yellow fever mosquito, LVP_AGWG)</name>
+    <division>Metazoa</division>
+    <taxonomy>7159</taxonomy>
+    <db_name>aedes_aegypti_lvpagwg</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Bradyrhizobium diazoefficiens USDA 110</name>
+    <name>Aeromonas hydrophila subsp. hydrophila ATCC 7966 (GCA_000014805)</name>
     <division>Bacteria</division>
-    <taxonomy>224911</taxonomy>
-    <db_name>bradyrhizobium_diazoefficiens_usda_110</db_name>
+    <taxonomy>380703</taxonomy>
+    <db_name>aeromonas_hydrophila_subsp_hydrophila_atcc_7966_gca_000014805</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Solanum lycopersicum</name>
+    <name>Aeropyrum pernix K1 (GCA_000011125)</name>
+    <division>Bacteria</division>
+    <taxonomy>272557</taxonomy>
+    <db_name>aeropyrum_pernix_k1_gca_000011125</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Agrobacterium fabrum str. C58 (GCA_000092025)</name>
+    <division>Bacteria</division>
+    <taxonomy>176299</taxonomy>
+    <db_name>agrobacterium_fabrum_str_c58_gca_000092025</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Aliivibrio fischeri ES114 (GCA_000011805)</name>
+    <division>Bacteria</division>
+    <taxonomy>312309</taxonomy>
+    <db_name>aliivibrio_fischeri_es114_gca_000011805</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Amborella trichopoda</name>
     <division>Plants</division>
-    <taxonomy>4081</taxonomy>
-    <db_name>solanum_lycopersicum</db_name>
+    <taxonomy>13333</taxonomy>
+    <db_name>amborella_trichopoda</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Vitis vinifera</name>
-    <division>Plants</division>
-    <taxonomy>29760</taxonomy>
-    <db_name>vitis_vinifera</db_name>
+    <name>Amphimedon queenslandica (Demosponge)</name>
+    <division>Metazoa</division>
+    <taxonomy>400682</taxonomy>
+    <db_name>amphimedon_queenslandica_gca000090795v2rs</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Anaplasma phagocytophilum str. HZ (GCA_000013125)</name>
+    <division>Bacteria</division>
+    <taxonomy>212042</taxonomy>
+    <db_name>anaplasma_phagocytophilum_str_hz_gca_000013125</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Anopheles gambiae (African malaria mosquito, PEST) - GCA_000005575.1</name>
+    <division>Metazoa</division>
+    <taxonomy>7165</taxonomy>
+    <db_name>anopheles_gambiae</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Apis mellifera (Honey bee, DH4)</name>
+    <division>Metazoa</division>
+    <taxonomy>7460</taxonomy>
+    <db_name>apis_mellifera</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Aquifex aeolicus VF5 (GCA_000008625)</name>
+    <division>Bacteria</division>
+    <taxonomy>224324</taxonomy>
+    <db_name>aquifex_aeolicus_vf5_gca_000008625</db_name>
     <Published>Yes</Published>
   </node>
   <node>
@@ -50,6 +99,181 @@
     <Published>Yes</Published>
   </node>
   <node>
+    <name>Archaeoglobus fulgidus DSM 4304 (GCA_000008665)</name>
+    <division>Bacteria</division>
+    <taxonomy>224325</taxonomy>
+    <db_name>archaeoglobus_fulgidus_dsm_4304_gca_000008665</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Aspergillus nidulans</name>
+    <division>Fungi</division>
+    <taxonomy>227321</taxonomy>
+    <db_name>aspergillus_nidulans</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Azotobacter vinelandii DJ (GCA_000021045)</name>
+    <division>Bacteria</division>
+    <taxonomy>322710</taxonomy>
+    <db_name>azotobacter_vinelandii_dj_gca_000021045</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Bacillus subtilis subsp. subtilis str. 168 (GCA_000009045)</name>
+    <division>Bacteria</division>
+    <taxonomy>224308</taxonomy>
+    <db_name>bacillus_subtilis_subsp_subtilis_str_168_gca_000009045</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Bacteroides thetaiotaomicron VPI-5482 (GCA_000011065)</name>
+    <division>Bacteria</division>
+    <taxonomy>226186</taxonomy>
+    <db_name>bacteroides_thetaiotaomicron_vpi_5482_gca_000011065</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Bartonella henselae str. Houston-1 (GCA_000046705)</name>
+    <division>Bacteria</division>
+    <taxonomy>283166</taxonomy>
+    <db_name>bartonella_henselae_str_houston_1_gca_000046705</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Bifidobacterium longum NCC2705 (GCA_000007525)</name>
+    <division>Bacteria</division>
+    <taxonomy>206672</taxonomy>
+    <db_name>bifidobacterium_longum_ncc2705_gca_000007525</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Bigelowiella natans</name>
+    <division>Protists</division>
+    <taxonomy>753081</taxonomy>
+    <db_name>bigelowiella_natans</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Borreliella burgdorferi B31 (GCA_000008685)</name>
+    <division>Bacteria</division>
+    <taxonomy>224326</taxonomy>
+    <db_name>borreliella_burgdorferi_b31_gca_000008685</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Brachypodium distachyon</name>
+    <division>Plants</division>
+    <taxonomy>15368</taxonomy>
+    <db_name>brachypodium_distachyon</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Bradyrhizobium diazoefficiens USDA 110 (GCA_000011365)</name>
+    <division>Bacteria</division>
+    <taxonomy>224911</taxonomy>
+    <db_name>bradyrhizobium_diazoefficiens_usda_110_gca_000011365</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Brucella abortus bv. 1 str. 9-941 (GCA_000008145)</name>
+    <division>Bacteria</division>
+    <taxonomy>262698</taxonomy>
+    <db_name>brucella_abortus_bv_1_str_9_941_gca_000008145</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Brugia malayi (Nematode, FR3)</name>
+    <division>Metazoa</division>
+    <taxonomy>6279</taxonomy>
+    <db_name>brugia_malayi</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Buchnera aphidicola str. APS (Acyrthosiphon pisum) (GCA_000009605)</name>
+    <division>Bacteria</division>
+    <taxonomy>107806</taxonomy>
+    <db_name>buchnera_aphidicola_str_aps_acyrthosiphon_pisum__gca_000009605</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Burkholderia pseudomallei 1710b (GCA_000012785)</name>
+    <division>Bacteria</division>
+    <taxonomy>320372</taxonomy>
+    <db_name>burkholderia_pseudomallei_1710b_gca_000012785</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>C.savignyi</name>
+    <division>Vertebrates</division>
+    <taxonomy>51511</taxonomy>
+    <db_name>ciona_savignyi</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Caenorhabditis elegans (Nematode, N2)</name>
+    <division>Metazoa</division>
+    <taxonomy>6239</taxonomy>
+    <db_name>caenorhabditis_elegans</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Campylobacter jejuni subsp. jejuni NCTC 11168 = ATCC 700819 (GCA_000009085)</name>
+    <division>Bacteria</division>
+    <taxonomy>192222</taxonomy>
+    <db_name>campylobacter_jejuni_subsp_jejuni_nctc_11168_atcc_700819_gca_000009085</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Candidatus Korarchaeum cryptofilum OPF8 (GCA_000019605)</name>
+    <division>Bacteria</division>
+    <taxonomy>374847</taxonomy>
+    <db_name>candidatus_korarchaeum_cryptofilum_opf8_gca_000019605</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Candidatus Koribacter versatilis Ellin345 (GCA_000014005)</name>
+    <division>Bacteria</division>
+    <taxonomy>204669</taxonomy>
+    <db_name>candidatus_koribacter_versatilis_ellin345_gca_000014005</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Caulobacter vibrioides CB15 (GCA_000006905)</name>
+    <division>Bacteria</division>
+    <taxonomy>190650</taxonomy>
+    <db_name>caulobacter_vibrioides_cb15_gca_000006905</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Cenarchaeum symbiosum A (GCA_000200715)</name>
+    <division>Bacteria</division>
+    <taxonomy>414004</taxonomy>
+    <db_name>cenarchaeum_symbiosum_a_gca_000200715</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Chicken</name>
+    <division>Vertebrates</division>
+    <taxonomy>9031</taxonomy>
+    <db_name>gallus_gallus</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Chimpanzee</name>
+    <division>Vertebrates</division>
+    <taxonomy>9598</taxonomy>
+    <db_name>pan_troglodytes</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Chlamydia trachomatis D/UW-3/CX (GCA_000008725)</name>
+    <division>Bacteria</division>
+    <taxonomy>272561</taxonomy>
+    <db_name>chlamydia_trachomatis_d_uw_3_cx_gca_000008725</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
     <name>Chlamydomonas reinhardtii</name>
     <division>Plants</division>
     <taxonomy>3055</taxonomy>
@@ -57,87 +281,780 @@
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Cyanidioschyzon merolae strain 10D</name>
+    <name>Chlorobaculum tepidum TLS (GCA_000006985)</name>
+    <division>Bacteria</division>
+    <taxonomy>194439</taxonomy>
+    <db_name>chlorobaculum_tepidum_tls_gca_000006985</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Chloroflexus aurantiacus J-10-fl (GCA_000018865)</name>
+    <division>Bacteria</division>
+    <taxonomy>324602</taxonomy>
+    <db_name>chloroflexus_aurantiacus_j_10_fl_gca_000018865</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Clostridioides difficile 630 (GCA_000009205)</name>
+    <division>Bacteria</division>
+    <taxonomy>272563</taxonomy>
+    <db_name>clostridioides_difficile_630_gca_000009205</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Coxiella burnetii RSA 493 (GCA_000007765)</name>
+    <division>Bacteria</division>
+    <taxonomy>227377</taxonomy>
+    <db_name>coxiella_burnetii_rsa_493_gca_000007765</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Cryptomonas paramecium str. CCAP977/2A (GCA_000194455.1)</name>
+    <division>Protists</division>
+    <taxonomy>2898</taxonomy>
+    <db_name>cryptomonas_paramecium_gca_000194455</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Cutibacterium acnes KPA171202 (GCA_000008345)</name>
+    <division>Bacteria</division>
+    <taxonomy>267747</taxonomy>
+    <db_name>cutibacterium_acnes_kpa171202_gca_000008345</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Cyanidioschyzon merolae</name>
     <division>Plants</division>
     <taxonomy>280699</taxonomy>
     <db_name>cyanidioschyzon_merolae</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Oryza sativa</name>
+    <name>Daphnia pulex (Common water flea, KAP4)</name>
+    <division>Metazoa</division>
+    <taxonomy>6669</taxonomy>
+    <db_name>daphnia_pulex_gca021134715v1rs</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Deinococcus radiodurans R1 (GCA_000008565)</name>
+    <division>Bacteria</division>
+    <taxonomy>243230</taxonomy>
+    <db_name>deinococcus_radiodurans_r1_gca_000008565</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Desulfovibrio vulgaris str. Hildenborough (GCA_000195755)</name>
+    <division>Bacteria</division>
+    <taxonomy>882</taxonomy>
+    <db_name>desulfovibrio_vulgaris_str_hildenborough_gca_000195755</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Dictyoglomus turgidum DSM 6724 (GCA_000021645)</name>
+    <division>Bacteria</division>
+    <taxonomy>515635</taxonomy>
+    <db_name>dictyoglomus_turgidum_dsm_6724_gca_000021645</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Dictyostelium discoideum</name>
+    <division>Protists</division>
+    <taxonomy>352472</taxonomy>
+    <db_name>dictyostelium_discoideum</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Drosophila melanogaster - (Fruit fly)</name>
+    <division>Metazoa</division>
+    <taxonomy>7227</taxonomy>
+    <db_name>drosophila_melanogaster</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Emiliania huxleyi</name>
+    <division>Protists</division>
+    <taxonomy>280463</taxonomy>
+    <db_name>emiliania_huxleyi</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Enterobacter cloacae subsp. cloacae ATCC 13047 (GCA_000025565)</name>
+    <division>Bacteria</division>
+    <taxonomy>716541</taxonomy>
+    <db_name>enterobacter_cloacae_subsp_cloacae_atcc_13047_gca_000025565</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Enterococcus faecalis V583 (GCA_000007785)</name>
+    <division>Bacteria</division>
+    <taxonomy>226185</taxonomy>
+    <db_name>enterococcus_faecalis_v583_gca_000007785</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Escherichia coli str. K-12 substr. MG1655 str. K12 (GCA_000005845)</name>
+    <division>Bacteria</division>
+    <taxonomy>511145</taxonomy>
+    <db_name>escherichia_coli_str_k_12_substr_mg1655_gca_000005845</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Flavobacterium psychrophilum JIP02/86 (GCA_000064305)</name>
+    <division>Bacteria</division>
+    <taxonomy>402612</taxonomy>
+    <db_name>flavobacterium_psychrophilum_jip02_86_gca_000064305</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Francisella tularensis subsp. tularensis SCHU S4 str. Schu S4 (GCA_000008985)</name>
+    <division>Bacteria</division>
+    <taxonomy>177416</taxonomy>
+    <db_name>francisella_tularensis_subsp_tularensis_schu_s4_gca_000008985</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Fusobacterium nucleatum subsp. nucleatum ATCC 25586 (GCA_000007325)</name>
+    <division>Bacteria</division>
+    <taxonomy>190304</taxonomy>
+    <db_name>fusobacterium_nucleatum_subsp_nucleatum_atcc_25586_gca_000007325</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Gardnerella vaginalis 0288E (GCA_000263555)</name>
+    <division>Bacteria</division>
+    <taxonomy>698952</taxonomy>
+    <db_name>gardnerella_vaginalis_0288e_gca_000263555</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Geobacter sulfurreducens PCA (GCA_000007985)</name>
+    <division>Bacteria</division>
+    <taxonomy>243231</taxonomy>
+    <db_name>geobacter_sulfurreducens_pca_gca_000007985</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Giardia intestinalis - GCA_000002435.2</name>
+    <division>Protists</division>
+    <taxonomy>5741</taxonomy>
+    <db_name>giardia_intestinalis_gca000002435v2</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Gigantopelta aegis (Deep sea snail, Gae_Host)</name>
+    <division>Metazoa</division>
+    <taxonomy>1735272</taxonomy>
+    <db_name>gigantopelta_aegis_gca016097555v1</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Gloeobacter violaceus PCC 7421 (GCA_000011385)</name>
+    <division>Bacteria</division>
+    <taxonomy>251221</taxonomy>
+    <db_name>gloeobacter_violaceus_pcc_7421_gca_000011385</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Green anole</name>
+    <division>Vertebrates</division>
+    <taxonomy>28377</taxonomy>
+    <db_name>anolis_carolinensis</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Guillardia theta CCMP2712</name>
+    <division>Protists</division>
+    <taxonomy>905079</taxonomy>
+    <db_name>guillardia_theta</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Haemophilus influenzae Rd KW20 (GCA_000027305)</name>
+    <division>Bacteria</division>
+    <taxonomy>71421</taxonomy>
+    <db_name>haemophilus_influenzae_rd_kw20_gca_000027305</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Haloarcula marismortui ATCC 43049 (GCA_000011085)</name>
+    <division>Bacteria</division>
+    <taxonomy>272569</taxonomy>
+    <db_name>haloarcula_marismortui_atcc_43049_gca_000011085</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Halobacterium salinarum R1 (GCA_000069025)</name>
+    <division>Bacteria</division>
+    <taxonomy>478009</taxonomy>
+    <db_name>halobacterium_salinarum_r1_gca_000069025</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Haloferax volcanii DS2 (GCA_000025685)</name>
+    <division>Bacteria</division>
+    <taxonomy>309800</taxonomy>
+    <db_name>haloferax_volcanii_ds2_gca_000025685</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Helicobacter pylori 26695 (GCA_000008525)</name>
+    <division>Bacteria</division>
+    <taxonomy>85962</taxonomy>
+    <db_name>helicobacter_pylori_26695_gca_000008525</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Heliconius melpomene (Postman butterfly)</name>
+    <division>Metazoa</division>
+    <taxonomy>34740</taxonomy>
+    <db_name>heliconius_melpomene</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Helobdella robusta (Freshwater leech)</name>
+    <division>Metazoa</division>
+    <taxonomy>6412</taxonomy>
+    <db_name>helobdella_robusta</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Human</name>
+    <division>Vertebrates</division>
+    <taxonomy>9606</taxonomy>
+    <db_name>homo_sapiens</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Hydra vulgaris (Swiftwater hydra)</name>
+    <division>Metazoa</division>
+    <taxonomy>6087</taxonomy>
+    <db_name>hydra_vulgaris_gca038396675v1rs</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Hyperthermus butylicus DSM 5456 (GCA_000015145)</name>
+    <division>Bacteria</division>
+    <taxonomy>415426</taxonomy>
+    <db_name>hyperthermus_butylicus_dsm_5456_gca_000015145</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Klebsiella pneumoniae subsp. pneumoniae MGH 78578 (GCA_000016305)</name>
+    <division>Bacteria</division>
+    <taxonomy>272620</taxonomy>
+    <db_name>klebsiella_pneumoniae_subsp_pneumoniae_mgh_78578_gca_000016305</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Lactobacillus plantarum WCFS1 (GCA_000203855)</name>
+    <division>Bacteria</division>
+    <taxonomy>220668</taxonomy>
+    <db_name>lactobacillus_plantarum_wcfs1_gca_000203855</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Lactococcus lactis subsp. lactis Il1403 (GCA_000006865)</name>
+    <division>Bacteria</division>
+    <taxonomy>272623</taxonomy>
+    <db_name>lactococcus_lactis_subsp_lactis_il1403_gca_000006865</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Leishmania major</name>
+    <division>Protists</division>
+    <taxonomy>347515</taxonomy>
+    <db_name>leishmania_major</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Leptospira interrogans serovar Lai str. 56601 (GCA_000092565)</name>
+    <division>Bacteria</division>
+    <taxonomy>189518</taxonomy>
+    <db_name>leptospira_interrogans_serovar_lai_str_56601_gca_000092565</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Leuconostoc mesenteroides subsp. mesenteroides ATCC 8293 (GCA_000014445)</name>
+    <division>Bacteria</division>
+    <taxonomy>203120</taxonomy>
+    <db_name>leuconostoc_mesenteroides_subsp_mesenteroides_atcc_8293_gca_000014445</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Lingula anatina (Lamp shell, Amm_Jpn)</name>
+    <division>Metazoa</division>
+    <taxonomy>7574</taxonomy>
+    <db_name>lingula_anatina_gca001039355v2</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Listeria monocytogenes EGD-e (GCA_000196035)</name>
+    <division>Bacteria</division>
+    <taxonomy>169963</taxonomy>
+    <db_name>listeria_monocytogenes_egd_e_gca_000196035</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Lysinibacillus sphaericus C3-41 (GCA_000017965)</name>
+    <division>Bacteria</division>
+    <taxonomy>444177</taxonomy>
+    <db_name>lysinibacillus_sphaericus_c3_41_gca_000017965</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Lytechinus variegatus (Green sea urchin, NC3)</name>
+    <division>Metazoa</division>
+    <taxonomy>7654</taxonomy>
+    <db_name>lytechinus_variegatus_gca018143015v1</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Marchantia polymorpha</name>
+    <division>Plants</division>
+    <taxonomy>3197</taxonomy>
+    <db_name>marchantia_polymorpha</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Mesoplasma florum L1 (GCA_000008305)</name>
+    <division>Bacteria</division>
+    <taxonomy>265311</taxonomy>
+    <db_name>mesoplasma_florum_l1_gca_000008305</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Methanobrevibacter smithii ATCC 35061 (GCA_000016525)</name>
+    <division>Bacteria</division>
+    <taxonomy>420247</taxonomy>
+    <db_name>methanobrevibacter_smithii_atcc_35061_gca_000016525</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Methanocaldococcus jannaschii DSM 2661 (GCA_000091665)</name>
+    <division>Bacteria</division>
+    <taxonomy>243232</taxonomy>
+    <db_name>methanocaldococcus_jannaschii_dsm_2661_gca_000091665</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Methanococcus maripaludis S2 (GCA_000011585)</name>
+    <division>Bacteria</division>
+    <taxonomy>267377</taxonomy>
+    <db_name>methanococcus_maripaludis_s2_gca_000011585</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Methanopyrus kandleri AV19 (GCA_000007185)</name>
+    <division>Bacteria</division>
+    <taxonomy>190192</taxonomy>
+    <db_name>methanopyrus_kandleri_av19_gca_000007185</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Methanosarcina acetivorans C2A (GCA_000007345)</name>
+    <division>Bacteria</division>
+    <taxonomy>188937</taxonomy>
+    <db_name>methanosarcina_acetivorans_c2a_gca_000007345</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Methanospirillum hungatei JF-1 (GCA_000013445)</name>
+    <division>Bacteria</division>
+    <taxonomy>323259</taxonomy>
+    <db_name>methanospirillum_hungatei_jf_1_gca_000013445</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Methanothermobacter thermautotrophicus str. Delta H (GCA_000008645)</name>
+    <division>Bacteria</division>
+    <taxonomy>187420</taxonomy>
+    <db_name>methanothermobacter_thermautotrophicus_str_delta_h_gca_000008645</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Micrococcus luteus NCTC 2665 (GCA_000023205)</name>
+    <division>Bacteria</division>
+    <taxonomy>465515</taxonomy>
+    <db_name>micrococcus_luteus_nctc_2665_gca_000023205</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Microcystis aeruginosa NIES-843 (GCA_000010625)</name>
+    <division>Bacteria</division>
+    <taxonomy>449447</taxonomy>
+    <db_name>microcystis_aeruginosa_nies_843_gca_000010625</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Mnemiopsis leidyi (Warty comb jelly)</name>
+    <division>Metazoa</division>
+    <taxonomy>27923</taxonomy>
+    <db_name>mnemiopsis_leidyi</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Monosiga brevicollis MX1 (GCA_000002865.1)</name>
+    <division>Protists</division>
+    <taxonomy>431895</taxonomy>
+    <db_name>monosiga_brevicollis_mx1_gca_000002865</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Moorella thermoacetica ATCC 39073 (GCA_000013105)</name>
+    <division>Bacteria</division>
+    <taxonomy>264732</taxonomy>
+    <db_name>moorella_thermoacetica_atcc_39073_gca_000013105</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Mouse</name>
+    <division>Vertebrates</division>
+    <taxonomy>10090</taxonomy>
+    <db_name>mus_musculus</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Mycoplasma pneumoniae M129 (GCA_000027345)</name>
+    <division>Bacteria</division>
+    <taxonomy>272634</taxonomy>
+    <db_name>mycoplasma_pneumoniae_m129_gca_000027345</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Mycosarcoma maydis</name>
+    <division>Fungi</division>
+    <taxonomy>5270</taxonomy>
+    <db_name>ustilago_maydis</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Myxococcus xanthus DK 1622 (GCA_000012685)</name>
+    <division>Bacteria</division>
+    <taxonomy>246197</taxonomy>
+    <db_name>myxococcus_xanthus_dk_1622_gca_000012685</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Nanoarchaeum equitans Kin4-M (GCA_000008085)</name>
+    <division>Bacteria</division>
+    <taxonomy>228908</taxonomy>
+    <db_name>nanoarchaeum_equitans_kin4_m_gca_000008085</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Natronomonas pharaonis DSM 2160 (GCA_000026045)</name>
+    <division>Bacteria</division>
+    <taxonomy>348780</taxonomy>
+    <db_name>natronomonas_pharaonis_dsm_2160_gca_000026045</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Neisseria meningitidis Z2491 (GCA_000009105)</name>
+    <division>Bacteria</division>
+    <taxonomy>122587</taxonomy>
+    <db_name>neisseria_meningitidis_z2491_gca_000009105</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Neurospora crassa</name>
+    <division>Fungi</division>
+    <taxonomy>367110</taxonomy>
+    <db_name>neurospora_crassa</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Nitrosopumilus maritimus SCM1 (GCA_000018465)</name>
+    <division>Bacteria</division>
+    <taxonomy>436308</taxonomy>
+    <db_name>nitrosopumilus_maritimus_scm1_gca_000018465</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Nostoc punctiforme PCC 73102 (GCA_000020025)</name>
+    <division>Bacteria</division>
+    <taxonomy>63737</taxonomy>
+    <db_name>nostoc_punctiforme_pcc_73102_gca_000020025</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Octopus bimaculoides (California two-spot octopus, UCB-OBI-ISO-001)</name>
+    <division>Metazoa</division>
+    <taxonomy>37653</taxonomy>
+    <db_name>octopus_bimaculoides_gca001194135v2rs</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Opossum</name>
+    <division>Vertebrates</division>
+    <taxonomy>13616</taxonomy>
+    <db_name>monodelphis_domestica</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Oryza sativa Japonica Group</name>
     <division>Plants</division>
     <taxonomy>39947</taxonomy>
     <db_name>oryza_sativa</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Physcomitrella patens subsp. patens</name>
-    <division>Plants</division>
-    <taxonomy>145481</taxonomy>
-    <db_name>physcomitrella_patens</db_name>
+    <name>Paracoccus denitrificans PD1222 (GCA_000203895)</name>
+    <division>Bacteria</division>
+    <taxonomy>318586</taxonomy>
+    <db_name>paracoccus_denitrificans_pd1222_gca_000203895</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Schizosaccharomyces pombe h978-</name>
-    <division>Fungi</division>
-    <taxonomy>284812</taxonomy>
-    <db_name>schizosaccharomyces_pombe</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Trichoplax adhaerens</name>
+    <name>Parasteatoda tepidariorum (Common house spider, YZ-2023)</name>
     <division>Metazoa</division>
-    <taxonomy>10228</taxonomy>
-    <db_name>trichoplax_adhaerens</db_name>
+    <taxonomy>114398</taxonomy>
+    <db_name>parasteatoda_tepidariorum_gca043381705v1rs</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Ustilago maydis 521</name>
-    <division>Fungi</division>
-    <taxonomy>237631</taxonomy>
-    <db_name>ustilago_maydis</db_name>
+    <name>Pasteurella multocida subsp. multocida str. Pm70 (GCA_000006825)</name>
+    <division>Bacteria</division>
+    <taxonomy>272843</taxonomy>
+    <db_name>pasteurella_multocida_subsp_multocida_str_pm70_gca_000006825</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Zymoseptoria tritici</name>
-    <division>Fungi</division>
-    <taxonomy>336722</taxonomy>
-    <db_name>zymoseptoria_tritici</db_name>
+    <name>Pediculus humanus corporis (Human body louse, USDA)</name>
+    <division>Metazoa</division>
+    <taxonomy>121224</taxonomy>
+    <db_name>pediculus_humanus</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Puccinia graminis f. sp. tritici CRL 75-36-700-3</name>
+    <name>Phaeodactylum tricornutum</name>
+    <division>Protists</division>
+    <taxonomy>556484</taxonomy>
+    <db_name>phaeodactylum_tricornutum</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Physcomitrium patens</name>
+    <division>Plants</division>
+    <taxonomy>3218</taxonomy>
+    <db_name>physcomitrium_patens</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Phytophthora infestans</name>
+    <division>Protists</division>
+    <taxonomy>403677</taxonomy>
+    <db_name>phytophthora_infestans</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Plasmodium falciparum - GCA_000002765.3</name>
+    <division>Protists</division>
+    <taxonomy>36329</taxonomy>
+    <db_name>plasmodium_falciparum</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Platypus</name>
+    <division>Vertebrates</division>
+    <taxonomy>9258</taxonomy>
+    <db_name>ornithorhynchus_anatinus</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Porphyromonas gingivalis W83 (GCA_000007585)</name>
+    <division>Bacteria</division>
+    <taxonomy>242619</taxonomy>
+    <db_name>porphyromonas_gingivalis_w83_gca_000007585</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Prochlorococcus marinus subsp. marinus str. CCMP1375 (GCA_000007925)</name>
+    <division>Bacteria</division>
+    <taxonomy>167539</taxonomy>
+    <db_name>prochlorococcus_marinus_subsp_marinus_str_ccmp1375_gca_000007925</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Proteus mirabilis HI4320 (GCA_000069965)</name>
+    <division>Bacteria</division>
+    <taxonomy>529507</taxonomy>
+    <db_name>proteus_mirabilis_hi4320_gca_000069965</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Puccinia graminis</name>
     <division>Fungi</division>
     <taxonomy>418459</taxonomy>
     <db_name>puccinia_graminis</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Saccharomyces cerevisiae S288c</name>
+    <name>Pyrobaculum aerophilum str. IM2 (GCA_000007225)</name>
+    <division>Bacteria</division>
+    <taxonomy>178306</taxonomy>
+    <db_name>pyrobaculum_aerophilum_str_im2_gca_000007225</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Pyrococcus horikoshii OT3 (GCA_000011105)</name>
+    <division>Bacteria</division>
+    <taxonomy>70601</taxonomy>
+    <db_name>pyrococcus_horikoshii_ot3_gca_000011105</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Ralstonia solanacearum GMI1000 (GCA_000009125)</name>
+    <division>Bacteria</division>
+    <taxonomy>267608</taxonomy>
+    <db_name>ralstonia_solanacearum_gmi1000_gca_000009125</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Rhizobium leguminosarum bv. viciae 3841 (GCA_000009265)</name>
+    <division>Bacteria</division>
+    <taxonomy>216596</taxonomy>
+    <db_name>rhizobium_leguminosarum_bv_viciae_3841_gca_000009265</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Rhodobacter sphaeroides 2.4.1 (GCA_000012905)</name>
+    <division>Bacteria</division>
+    <taxonomy>272943</taxonomy>
+    <db_name>rhodobacter_sphaeroides_2_4_1_gca_000012905</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Rhodopirellula baltica SH 1 (GCA_000196115)</name>
+    <division>Bacteria</division>
+    <taxonomy>243090</taxonomy>
+    <db_name>rhodopirellula_baltica_sh_1_gca_000196115</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Rhodospirillum rubrum ATCC 11170 (GCA_000013085)</name>
+    <division>Bacteria</division>
+    <taxonomy>269796</taxonomy>
+    <db_name>rhodospirillum_rubrum_atcc_11170_gca_000013085</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Rickettsia prowazekii str. Madrid E (GCA_000195735)</name>
+    <division>Bacteria</division>
+    <taxonomy>272947</taxonomy>
+    <db_name>rickettsia_prowazekii_str_madrid_e_gca_000195735</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Saccharolobus solfataricus P2 (GCA_000007005)</name>
+    <division>Bacteria</division>
+    <taxonomy>273057</taxonomy>
+    <db_name>saccharolobus_solfataricus_p2_gca_000007005</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Saccharomyces cerevisiae</name>
     <division>Fungi</division>
     <taxonomy>559292</taxonomy>
     <db_name>saccharomyces_cerevisiae</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Schistosoma mansoni</name>
+    <name>Salinibacter ruber DSM 13855 (GCA_000013045)</name>
+    <division>Bacteria</division>
+    <taxonomy>309807</taxonomy>
+    <db_name>salinibacter_ruber_dsm_13855_gca_000013045</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Schistosoma mansoni (Flatworm)</name>
     <division>Metazoa</division>
     <taxonomy>6183</taxonomy>
     <db_name>schistosoma_mansoni</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Strigamia maritima</name>
+    <name>Schizosaccharomyces pombe</name>
+    <division>Fungi</division>
+    <taxonomy>284812</taxonomy>
+    <db_name>schizosaccharomyces_pombe</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Selaginella moellendorffii</name>
+    <division>Plants</division>
+    <taxonomy>88036</taxonomy>
+    <db_name>selaginella_moellendorffii</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Shigella dysenteriae Sd197 (GCA_000012005)</name>
+    <division>Bacteria</division>
+    <taxonomy>300267</taxonomy>
+    <db_name>shigella_dysenteriae_sd197_gca_000012005</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Sinorhizobium meliloti 1021 (GCA_000006965)</name>
+    <division>Bacteria</division>
+    <taxonomy>266834</taxonomy>
+    <db_name>sinorhizobium_meliloti_1021_gca_000006965</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Solanum lycopersicum Heinz1706</name>
+    <division>Plants</division>
+    <taxonomy>4081</taxonomy>
+    <db_name>solanum_lycopersicum_gca000188115v5cm</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Staphylococcus aureus subsp. aureus N315 (GCA_000009645)</name>
+    <division>Bacteria</division>
+    <taxonomy>158879</taxonomy>
+    <db_name>staphylococcus_aureus_subsp_aureus_n315_gca_000009645</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Stenotrophomonas maltophilia K279a (GCA_000072485)</name>
+    <division>Bacteria</division>
+    <taxonomy>522373</taxonomy>
+    <db_name>stenotrophomonas_maltophilia_k279a_gca_000072485</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Stickleback</name>
+    <division>Vertebrates</division>
+    <taxonomy>481459</taxonomy>
+    <db_name>gasterosteus_aculeatus</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Streptococcus pneumoniae TIGR4 (GCA_000006885)</name>
+    <division>Bacteria</division>
+    <taxonomy>170187</taxonomy>
+    <db_name>streptococcus_pneumoniae_tigr4_gca_000006885</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Strigamia maritima (Soil centipede)</name>
     <division>Metazoa</division>
     <taxonomy>126957</taxonomy>
     <db_name>strigamia_maritima</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Strongylocentrotus purpuratus</name>
-    <division>Metazoa</division>
-    <taxonomy>7668</taxonomy>
-    <db_name>strongylocentrotus_purpuratus</db_name>
+    <name>Sumatran orangutan</name>
+    <division>Vertebrates</division>
+    <taxonomy>9601</taxonomy>
+    <db_name>pongo_abelii</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Synechocystis sp. PCC 6803 (GCA_000009725)</name>
+    <division>Bacteria</division>
+    <taxonomy>1148</taxonomy>
+    <db_name>synechocystis_sp_pcc_6803_gca_000009725</db_name>
     <Published>Yes</Published>
   </node>
   <node>
@@ -148,1060 +1065,165 @@
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Tetranychus urticae</name>
+    <name>Tetranychus urticae (Two-spotted spider mite)</name>
     <division>Metazoa</division>
     <taxonomy>32264</taxonomy>
     <db_name>tetranychus_urticae</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Guillardia theta</name>
+    <name>Thecamonas trahens ATCC 50062 (GCA_000142905.1)</name>
     <division>Protists</division>
-    <taxonomy>905079</taxonomy>
-    <db_name>guillardia_theta</db_name>
+    <taxonomy>461836</taxonomy>
+    <db_name>thecamonas_trahens_atcc_50062_gca_000142905</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Helobdella robusta</name>
+    <name>Thermanaerovibrio acidaminovorans DSM 6589 (GCA_000024905)</name>
+    <division>Bacteria</division>
+    <taxonomy>525903</taxonomy>
+    <db_name>thermanaerovibrio_acidaminovorans_dsm_6589_gca_000024905</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Thermococcus kodakarensis KOD1 (GCA_000009965)</name>
+    <division>Bacteria</division>
+    <taxonomy>69014</taxonomy>
+    <db_name>thermococcus_kodakarensis_kod1_gca_000009965</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Thermodesulfovibrio yellowstonii DSM 11347 (GCA_000020985)</name>
+    <division>Bacteria</division>
+    <taxonomy>289376</taxonomy>
+    <db_name>thermodesulfovibrio_yellowstonii_dsm_11347_gca_000020985</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Thermofilum pendens Hrk 5 (GCA_000015225)</name>
+    <division>Bacteria</division>
+    <taxonomy>368408</taxonomy>
+    <db_name>thermofilum_pendens_hrk_5_gca_000015225</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Thermoplasma acidophilum DSM 1728 (GCA_000195915)</name>
+    <division>Bacteria</division>
+    <taxonomy>273075</taxonomy>
+    <db_name>thermoplasma_acidophilum_dsm_1728_gca_000195915</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Thermosynechococcus elongatus BP-1 (GCA_000011345)</name>
+    <division>Bacteria</division>
+    <taxonomy>197221</taxonomy>
+    <db_name>thermosynechococcus_elongatus_bp_1_gca_000011345</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Thermotoga maritima MSB8 (GCA_000008545)</name>
+    <division>Bacteria</division>
+    <taxonomy>243274</taxonomy>
+    <db_name>thermotoga_maritima_msb8_gca_000008545</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Thermus thermophilus HB8 (GCA_000091545)</name>
+    <division>Bacteria</division>
+    <taxonomy>300852</taxonomy>
+    <db_name>thermus_thermophilus_hb8_gca_000091545</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Treponema pallidum subsp. pallidum str. Nichols (GCA_000008605)</name>
+    <division>Bacteria</division>
+    <taxonomy>243276</taxonomy>
+    <db_name>treponema_pallidum_subsp_pallidum_str_nichols_gca_000008605</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Tribolium castaneum (Red flour beetle, GA2)</name>
     <division>Metazoa</division>
-    <taxonomy>6412</taxonomy>
-    <db_name>helobdella_robusta</db_name>
+    <taxonomy>7070</taxonomy>
+    <db_name>tribolium_castaneum_gca031307605v1rs</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Leishmania major strain Friedlin</name>
-    <division>Protists</division>
-    <taxonomy>347515</taxonomy>
-    <db_name>leishmania_major</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Lottia gigantea</name>
+    <name>Trichoplax adhaerens (Placozoa, Grell-BS-1999)</name>
     <division>Metazoa</division>
-    <taxonomy>225164</taxonomy>
-    <db_name>lottia_gigantea</db_name>
+    <taxonomy>10228</taxonomy>
+    <db_name>trichoplax_adhaerens</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Nematostella vectensis</name>
-    <division>Metazoa</division>
-    <taxonomy>45351</taxonomy>
-    <db_name>nematostella_vectensis</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Neurospora crassa OR74A</name>
-    <division>Fungi</division>
-    <taxonomy>367110</taxonomy>
-    <db_name>neurospora_crassa</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Phaeodactylum tricornutum CCAP 1055/1</name>
-    <division>Protists</division>
-    <taxonomy>556484</taxonomy>
-    <db_name>phaeodactylum_tricornutum</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Phytophthora infestans T30-4</name>
-    <division>Protists</division>
-    <taxonomy>403677</taxonomy>
-    <db_name>phytophthora_infestans</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Plasmodium falciparum 3D7</name>
-    <division>Protists</division>
-    <taxonomy>36329</taxonomy>
-    <db_name>plasmodium_falciparum</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Giardia lamblia</name>
-    <division>Protists</division>
-    <taxonomy>184922</taxonomy>
-    <db_name>giardia_lamblia</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Amphimedon queenslandica</name>
-    <division>Metazoa</division>
-    <taxonomy>400682</taxonomy>
-    <db_name>amphimedon_queenslandica</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Anopheles gambiae</name>
-    <division>Metazoa</division>
-    <taxonomy>7165</taxonomy>
-    <db_name>anopheles_gambiae</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Apis mellifera</name>
-    <division>Metazoa</division>
-    <taxonomy>7460</taxonomy>
-    <db_name>apis_mellifera</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Aspergillus nidulans FGSC A4</name>
-    <division>Fungi</division>
-    <taxonomy>227321</taxonomy>
-    <db_name>aspergillus_nidulans</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Brugia malayi</name>
-    <division>Metazoa</division>
-    <taxonomy>6279</taxonomy>
-    <db_name>brugia_malayi</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Caenorhabditis elegans</name>
-    <division>Metazoa</division>
-    <taxonomy>6239</taxonomy>
-    <db_name>caenorhabditis_elegans</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Daphnia pulex</name>
-    <division>Metazoa</division>
-    <taxonomy>6669</taxonomy>
-    <db_name>daphnia_pulex</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Dictyostelium discoideum</name>
-    <division>Protists</division>
-    <taxonomy>44689</taxonomy>
-    <db_name>dictyostelium_discoideum</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Drosophila melanogaster</name>
-    <division>Metazoa</division>
-    <taxonomy>7227</taxonomy>
-    <db_name>drosophila_melanogaster</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Monodelphis domestica</name>
-    <division>Ensembl</division>
-    <taxonomy>13616</taxonomy>
-    <db_name>monodelphis_domestica</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Mus musculus</name>
-    <division>Ensembl</division>
-    <taxonomy>10090</taxonomy>
-    <db_name>mus_musculus</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Ornithorhynchus anatinus</name>
-    <division>Ensembl</division>
-    <taxonomy>9258</taxonomy>
-    <db_name>ornithorhynchus_anatinus</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Pan troglodytes</name>
-    <division>Ensembl</division>
-    <taxonomy>9598</taxonomy>
-    <db_name>pan_troglodytes</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Pongo abelii</name>
-    <division>Ensembl</division>
-    <taxonomy>9601</taxonomy>
-    <db_name>pongo_abelii</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Xenopus tropicalis</name>
-    <division>Ensembl</division>
+    <name>Tropical clawed frog</name>
+    <division>Vertebrates</division>
     <taxonomy>8364</taxonomy>
     <db_name>xenopus_tropicalis</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Anolis carolinensis</name>
-    <division>Ensembl</division>
-    <taxonomy>28377</taxonomy>
-    <db_name>anolis_carolinensis</db_name>
+    <name>Ureaplasma parvum serovar 3 str. ATCC 700970 (GCA_000006625)</name>
+    <division>Bacteria</division>
+    <taxonomy>273119</taxonomy>
+    <db_name>ureaplasma_parvum_serovar_3_str_atcc_700970_gca_000006625</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Ciona savignyi</name>
-    <division>Ensembl</division>
-    <taxonomy>51511</taxonomy>
-    <db_name>ciona_savignyi</db_name>
+    <name>Vibrio cholerae O1 biovar El Tor str. N16961 (GCA_000006745)</name>
+    <division>Bacteria</division>
+    <taxonomy>243277</taxonomy>
+    <db_name>vibrio_cholerae_o1_biovar_el_tor_str_n16961_gca_000006745</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Danio rerio</name>
-    <division>Ensembl</division>
+    <name>Vitis vinifera</name>
+    <division>Plants</division>
+    <taxonomy>29760</taxonomy>
+    <db_name>vitis_vinifera</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Wolbachia endosymbiont of Drosophila melanogaster (GCA_000008025)</name>
+    <division>Bacteria</division>
+    <taxonomy>163164</taxonomy>
+    <db_name>wolbachia_endosymbiont_of_drosophila_melanogaster_gca_000008025</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Xanthomonas campestris pv. campestris str. ATCC 33913 (GCA_000007145)</name>
+    <division>Bacteria</division>
+    <taxonomy>190485</taxonomy>
+    <db_name>xanthomonas_campestris_pv_campestris_str_atcc_33913_gca_000007145</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Yersinia pestis biovar Microtus str. 91001 (GCA_000007885)</name>
+    <division>Bacteria</division>
+    <taxonomy>229193</taxonomy>
+    <db_name>yersinia_pestis_biovar_microtus_str_91001_gca_000007885</db_name>
+    <Published>Yes</Published>
+  </node>
+  <node>
+    <name>Zebrafish</name>
+    <division>Vertebrates</division>
     <taxonomy>7955</taxonomy>
     <db_name>danio_rerio</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Gallus gallus</name>
-    <division>Ensembl</division>
-    <taxonomy>9031</taxonomy>
-    <db_name>gallus_gallus</db_name>
+    <name>Zootermopsis nevadensis (Nevada dampwood termite)</name>
+    <division>Metazoa</division>
+    <taxonomy>136037</taxonomy>
+    <db_name>zootermopsis_nevadensis</db_name>
     <Published>Yes</Published>
   </node>
   <node>
-    <name>Gasterosteus aculeatus</name>
-    <division>Ensembl</division>
-    <taxonomy>69293</taxonomy>
-    <db_name>gasterosteus_aculeatus</db_name>
+    <name>Zymoseptoria tritici</name>
+    <division>Fungi</division>
+    <taxonomy>336722</taxonomy>
+    <db_name>zymoseptoria_tritici</db_name>
     <Published>Yes</Published>
   </node>
-  <node>
-    <name>Homo sapiens</name>
-    <division>Ensembl</division>
-    <taxonomy>9606</taxonomy>
-    <db_name>homo_sapiens</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Yersinia pestis biovar Microtus str. 91001</name>
-    <division>Bacteria</division>
-    <taxonomy>229193</taxonomy>
-    <db_name>yersinia_pestis_biovar_microtus_str_91001</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Xanthomonas campestris pv. campestris str. ATCC 33913</name>
-    <division>Bacteria</division>
-    <taxonomy>190485</taxonomy>
-    <db_name>xanthomonas_campestris_pv_campestris_str_atcc_33913</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Wolbachia endosymbiont of Drosophila melanogaster</name>
-    <division>Bacteria</division>
-    <taxonomy>163164</taxonomy>
-    <db_name>wolbachia_endosymbiont_of_drosophila_melanogaster</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Vibrio cholerae O1 biovar El Tor str. N16961</name>
-    <division>Bacteria</division>
-    <taxonomy>243277</taxonomy>
-    <db_name>vibrio_cholerae_o1_biovar_el_tor_str_n16961</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Vibrio fischeri ES114</name>
-    <division>Bacteria</division>
-    <taxonomy>312309</taxonomy>
-    <db_name>vibrio_fischeri_es114</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Ureaplasma parvum serovar 3 str. ATCC 700970</name>
-    <division>Bacteria</division>
-    <taxonomy>273119</taxonomy>
-    <db_name>ureaplasma_parvum_serovar_3_str_atcc_700970</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermus thermophilus HB8</name>
-    <division>Bacteria</division>
-    <taxonomy>300852</taxonomy>
-    <db_name>thermus_thermophilus_hb8</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermosynechococcus elongatus BP-1</name>
-    <division>Bacteria</division>
-    <taxonomy>197221</taxonomy>
-    <db_name>thermosynechococcus_elongatus_bp_1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermotoga maritima MSB8 (ASM854v1)</name>
-    <division>Bacteria</division>
-    <taxonomy>243274</taxonomy>
-    <db_name>thermotoga_maritima_msb8_asm854v1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermococcus kodakarensis KOD1</name>
-    <division>Bacteria</division>
-    <taxonomy>69014</taxonomy>
-    <db_name>thermococcus_kodakarensis_kod1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermodesulfovibrio yellowstonii DSM 11347</name>
-    <division>Bacteria</division>
-    <taxonomy>289376</taxonomy>
-    <db_name>thermodesulfovibrio_yellowstonii_dsm_11347</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermofilum pendens Hrk 5</name>
-    <division>Bacteria</division>
-    <taxonomy>368408</taxonomy>
-    <db_name>thermofilum_pendens_hrk_5</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermoplasma acidophilum DSM 1728</name>
-    <division>Bacteria</division>
-    <taxonomy>273075</taxonomy>
-    <db_name>thermoplasma_acidophilum_dsm_1728</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Synechocystis sp. PCC 6803 (ASM972v1)</name>
-    <division>Bacteria</division>
-    <taxonomy>1148</taxonomy>
-    <db_name>synechocystis_sp_pcc_6803_asm972v1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Thermanaerovibrio acidaminovorans DSM 6589</name>
-    <division>Bacteria</division>
-    <taxonomy>525903</taxonomy>
-    <db_name>thermanaerovibrio_acidaminovorans_dsm_6589</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Sulfolobus solfataricus P2</name>
-    <division>Bacteria</division>
-    <taxonomy>273057</taxonomy>
-    <db_name>sulfolobus_solfataricus_p2</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Streptomyces coelicolor A3(2)</name>
-    <division>Bacteria</division>
-    <taxonomy>100226</taxonomy>
-    <db_name>streptomyces_coelicolor_a3_2_</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Streptococcus pneumoniae TIGR4</name>
-    <division>Bacteria</division>
-    <taxonomy>170187</taxonomy>
-    <db_name>streptococcus_pneumoniae_tigr4</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Stenotrophomonas maltophilia K279a</name>
-    <division>Bacteria</division>
-    <taxonomy>522373</taxonomy>
-    <db_name>stenotrophomonas_maltophilia_k279a</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Staphylococcus aureus subsp. aureus N315</name>
-    <division>Bacteria</division>
-    <taxonomy>158879</taxonomy>
-    <db_name>staphylococcus_aureus_subsp_aureus_n315</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Sinorhizobium meliloti 1021</name>
-    <division>Bacteria</division>
-    <taxonomy>266834</taxonomy>
-    <db_name>sinorhizobium_meliloti_1021</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Shewanella oneidensis MR-1</name>
-    <division>Bacteria</division>
-    <taxonomy>211586</taxonomy>
-    <db_name>shewanella_oneidensis_mr_1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Shigella dysenteriae Sd197</name>
-    <division>Bacteria</division>
-    <taxonomy>300267</taxonomy>
-    <db_name>shigella_dysenteriae_sd197</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Salmonella enterica subsp. enterica serovar Typhimurium str. LT2</name>
-    <division>Bacteria</division>
-    <taxonomy>99287</taxonomy>
-    <db_name>salmonella_enterica_subsp_enterica_serovar_typhimurium_str_lt2</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Salinibacter ruber DSM 13855</name>
-    <division>Bacteria</division>
-    <taxonomy>309807</taxonomy>
-    <db_name>salinibacter_ruber_dsm_13855</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Rickettsia prowazekii str. Madrid E</name>
-    <division>Bacteria</division>
-    <taxonomy>272947</taxonomy>
-    <db_name>rickettsia_prowazekii_str_madrid_e</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Rhodopirellula baltica SH 1</name>
-    <division>Bacteria</division>
-    <taxonomy>243090</taxonomy>
-    <db_name>rhodopirellula_baltica_sh_1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Rhodospirillum rubrum ATCC 11170</name>
-    <division>Bacteria</division>
-    <taxonomy>269796</taxonomy>
-    <db_name>rhodospirillum_rubrum_atcc_11170</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Rhizobium leguminosarum bv. viciae 3841</name>
-    <division>Bacteria</division>
-    <taxonomy>216596</taxonomy>
-    <db_name>rhizobium_leguminosarum_bv_viciae_3841</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Rhodobacter sphaeroides 2.4.1</name>
-    <division>Bacteria</division>
-    <taxonomy>272943</taxonomy>
-    <db_name>rhodobacter_sphaeroides_2_4_1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Pyrobaculum aerophilum str. IM2</name>
-    <division>Bacteria</division>
-    <taxonomy>178306</taxonomy>
-    <db_name>pyrobaculum_aerophilum_str_im2</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Pyrococcus horikoshii OT3</name>
-    <division>Bacteria</division>
-    <taxonomy>70601</taxonomy>
-    <db_name>pyrococcus_horikoshii_ot3</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Ralstonia solanacearum GMI1000</name>
-    <division>Bacteria</division>
-    <taxonomy>267608</taxonomy>
-    <db_name>ralstonia_solanacearum_gmi1000</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Proteus mirabilis HI4320</name>
-    <division>Bacteria</division>
-    <taxonomy>529507</taxonomy>
-    <db_name>proteus_mirabilis_hi4320</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Pseudomonas aeruginosa MPAO1/P2</name>
-    <division>Bacteria</division>
-    <taxonomy>1131758</taxonomy>
-    <db_name>pseudomonas_aeruginosa_mpao1_p2</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Propionibacterium acnes KPA171202</name>
-    <division>Bacteria</division>
-    <taxonomy>267747</taxonomy>
-    <db_name>propionibacterium_acnes_kpa171202</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Prochlorococcus marinus subsp. marinus str. CCMP1375</name>
-    <division>Bacteria</division>
-    <taxonomy>167539</taxonomy>
-    <db_name>prochlorococcus_marinus_subsp_marinus_str_ccmp1375</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Porphyromonas gingivalis W83</name>
-    <division>Bacteria</division>
-    <taxonomy>242619</taxonomy>
-    <db_name>porphyromonas_gingivalis_w83</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Prevotella intermedia 17</name>
-    <division>Bacteria</division>
-    <taxonomy>246198</taxonomy>
-    <db_name>prevotella_intermedia_17</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Pasteurella multocida subsp. multocida str. Pm70</name>
-    <division>Bacteria</division>
-    <taxonomy>272843</taxonomy>
-    <db_name>pasteurella_multocida_subsp_multocida_str_pm70</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Paracoccus denitrificans PD1222</name>
-    <division>Bacteria</division>
-    <taxonomy>318586</taxonomy>
-    <db_name>paracoccus_denitrificans_pd1222</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Nitrosopumilus maritimus SCM1</name>
-    <division>Bacteria</division>
-    <taxonomy>436308</taxonomy>
-    <db_name>nitrosopumilus_maritimus_scm1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Nostoc punctiforme PCC 73102</name>
-    <division>Bacteria</division>
-    <taxonomy>63737</taxonomy>
-    <db_name>nostoc_punctiforme_pcc_73102</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Neisseria meningitidis Z2491</name>
-    <division>Bacteria</division>
-    <taxonomy>122587</taxonomy>
-    <db_name>neisseria_meningitidis_z2491</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Mycoplasma pneumoniae M129</name>
-    <division>Bacteria</division>
-    <taxonomy>272634</taxonomy>
-    <db_name>mycoplasma_pneumoniae_m129</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Myxococcus xanthus DK 1622</name>
-    <division>Bacteria</division>
-    <taxonomy>246197</taxonomy>
-    <db_name>myxococcus_xanthus_dk_1622</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Nanoarchaeum equitans Kin4-M</name>
-    <division>Bacteria</division>
-    <taxonomy>228908</taxonomy>
-    <db_name>nanoarchaeum_equitans_kin4_m</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Natronomonas pharaonis DSM 2160</name>
-    <division>Bacteria</division>
-    <taxonomy>348780</taxonomy>
-    <db_name>natronomonas_pharaonis_dsm_2160</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Mycobacterium tuberculosis H37Rv (ASM19595v2)</name>
-    <division>Bacteria</division>
-    <taxonomy>83332</taxonomy>
-    <db_name>mycobacterium_tuberculosis_h37rv_asm19595v2</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Moraxella catarrhalis 7169</name>
-    <division>Bacteria</division>
-    <taxonomy>857581</taxonomy>
-    <db_name>moraxella_catarrhalis_7169</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Micrococcus luteus NCTC 2665</name>
-    <division>Bacteria</division>
-    <taxonomy>465515</taxonomy>
-    <db_name>micrococcus_luteus_nctc_2665</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Microcystis aeruginosa NIES-843</name>
-    <division>Bacteria</division>
-    <taxonomy>449447</taxonomy>
-    <db_name>microcystis_aeruginosa_nies_843</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Moorella thermoacetica ATCC 39073</name>
-    <division>Bacteria</division>
-    <taxonomy>264732</taxonomy>
-    <db_name>moorella_thermoacetica_atcc_39073</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanopyrus kandleri AV19</name>
-    <division>Bacteria</division>
-    <taxonomy>190192</taxonomy>
-    <db_name>methanopyrus_kandleri_av19</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanosarcina acetivorans C2A</name>
-    <division>Bacteria</division>
-    <taxonomy>188937</taxonomy>
-    <db_name>methanosarcina_acetivorans_c2a</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanospirillum hungatei JF-1</name>
-    <division>Bacteria</division>
-    <taxonomy>323259</taxonomy>
-    <db_name>methanospirillum_hungatei_jf_1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanothermobacter thermautotrophicus str. Delta H</name>
-    <division>Bacteria</division>
-    <taxonomy>187420</taxonomy>
-    <db_name>methanothermobacter_thermautotrophicus_str_delta_h</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanococcus maripaludis S2</name>
-    <division>Bacteria</division>
-    <taxonomy>267377</taxonomy>
-    <db_name>methanococcus_maripaludis_s2</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Mesoplasma florum L1</name>
-    <division>Bacteria</division>
-    <taxonomy>265311</taxonomy>
-    <db_name>mesoplasma_florum_l1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanobacterium formicicum DSM 3637</name>
-    <division>Bacteria</division>
-    <taxonomy>1204725</taxonomy>
-    <db_name>methanobacterium_formicicum_dsm_3637</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanobrevibacter smithii ATCC 35061</name>
-    <division>Bacteria</division>
-    <taxonomy>420247</taxonomy>
-    <db_name>methanobrevibacter_smithii_atcc_35061</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Methanocaldococcus jannaschii DSM 2661</name>
-    <division>Bacteria</division>
-    <taxonomy>243232</taxonomy>
-    <db_name>methanocaldococcus_jannaschii_dsm_2661</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Lysinibacillus sphaericus C3-41</name>
-    <division>Bacteria</division>
-    <taxonomy>444177</taxonomy>
-    <db_name>lysinibacillus_sphaericus_c3_41</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Mannheimia haemolytica serotype A2 str. OVINE</name>
-    <division>Bacteria</division>
-    <taxonomy>669261</taxonomy>
-    <db_name>mannheimia_haemolytica_serotype_a2_str_ovine</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Leuconostoc mesenteroides subsp. mesenteroides ATCC 8293</name>
-    <division>Bacteria</division>
-    <taxonomy>203120</taxonomy>
-    <db_name>leuconostoc_mesenteroides_subsp_mesenteroides_atcc_8293</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Listeria monocytogenes EGD-e</name>
-    <division>Bacteria</division>
-    <taxonomy>169963</taxonomy>
-    <db_name>listeria_monocytogenes_egd_e</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Leptospira interrogans serovar Lai str. 56601</name>
-    <division>Bacteria</division>
-    <taxonomy>189518</taxonomy>
-    <db_name>leptospira_interrogans_serovar_lai_str_56601</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Lactococcus lactis subsp. lactis Il1403</name>
-    <division>Bacteria</division>
-    <taxonomy>272623</taxonomy>
-    <db_name>lactococcus_lactis_subsp_lactis_il1403</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Legionella pneumophila str. Paris</name>
-    <division>Bacteria</division>
-    <taxonomy>297246</taxonomy>
-    <db_name>legionella_pneumophila_str_paris</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Lactobacillus plantarum WCFS1</name>
-    <division>Bacteria</division>
-    <taxonomy>220668</taxonomy>
-    <db_name>lactobacillus_plantarum_wcfs1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Klebsiella pneumoniae subsp. pneumoniae MGH 78578</name>
-    <division>Bacteria</division>
-    <taxonomy>272620</taxonomy>
-    <db_name>klebsiella_pneumoniae_subsp_pneumoniae_mgh_78578</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Hyperthermus butylicus DSM 5456</name>
-    <division>Bacteria</division>
-    <taxonomy>415426</taxonomy>
-    <db_name>hyperthermus_butylicus_dsm_5456</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Helicobacter pylori 26695 (ASM852v1)</name>
-    <division>Bacteria</division>
-    <taxonomy>85962</taxonomy>
-    <db_name>helicobacter_pylori_26695_asm852v1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Haemophilus influenzae Rd KW20</name>
-    <division>Bacteria</division>
-    <taxonomy>71421</taxonomy>
-    <db_name>haemophilus_influenzae_rd_kw20</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Haloarcula marismortui ATCC 43049</name>
-    <division>Bacteria</division>
-    <taxonomy>272569</taxonomy>
-    <db_name>haloarcula_marismortui_atcc_43049</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Halobacterium salinarum R1</name>
-    <division>Bacteria</division>
-    <taxonomy>478009</taxonomy>
-    <db_name>halobacterium_salinarum_r1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Geobacter sulfurreducens PCA</name>
-    <division>Bacteria</division>
-    <taxonomy>243231</taxonomy>
-    <db_name>geobacter_sulfurreducens_pca</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Gloeobacter violaceus PCC 7421</name>
-    <division>Bacteria</division>
-    <taxonomy>251221</taxonomy>
-    <db_name>gloeobacter_violaceus_pcc_7421</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Fusobacterium nucleatum subsp. nucleatum ATCC 25586</name>
-    <division>Bacteria</division>
-    <taxonomy>190304</taxonomy>
-    <db_name>fusobacterium_nucleatum_subsp_nucleatum_atcc_25586</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Gardnerella vaginalis 0288E</name>
-    <division>Bacteria</division>
-    <taxonomy>698952</taxonomy>
-    <db_name>gardnerella_vaginalis_0288e</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Francisella tularensis subsp. tularensis SCHU S4</name>
-    <division>Bacteria</division>
-    <taxonomy>177416</taxonomy>
-    <db_name>francisella_tularensis_subsp_tularensis_schu_s4</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Flavobacterium psychrophilum JIP02/86</name>
-    <division>Bacteria</division>
-    <taxonomy>402612</taxonomy>
-    <db_name>flavobacterium_psychrophilum_jip02_86</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Escherichia coli str. K-12 substr. MG1655</name>
-    <division>Bacteria</division>
-    <taxonomy>511145</taxonomy>
-    <db_name>escherichia_coli_str_k_12_substr_mg1655</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Enterobacter cloacae subsp. cloacae ATCC 13047</name>
-    <division>Bacteria</division>
-    <taxonomy>716541</taxonomy>
-    <db_name>enterobacter_cloacae_subsp_cloacae_atcc_13047</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Desulfovibrio vulgaris str. Hildenborough</name>
-    <division>Bacteria</division>
-    <taxonomy>882</taxonomy>
-    <db_name>desulfovibrio_vulgaris_str_hildenborough</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Dictyoglomus turgidum DSM 6724</name>
-    <division>Bacteria</division>
-    <taxonomy>515635</taxonomy>
-    <db_name>dictyoglomus_turgidum_dsm_6724</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Deinococcus radiodurans R1</name>
-    <division>Bacteria</division>
-    <taxonomy>243230</taxonomy>
-    <db_name>deinococcus_radiodurans_r1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Coxiella burnetii RSA 493</name>
-    <division>Bacteria</division>
-    <taxonomy>227377</taxonomy>
-    <db_name>coxiella_burnetii_rsa_493</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Corynebacterium glutamicum ATCC 13032 (ASM19633v1)</name>
-    <division>Bacteria</division>
-    <taxonomy>196627</taxonomy>
-    <db_name>corynebacterium_glutamicum_atcc_13032_asm19633v1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Clostridium botulinum A str. Hall</name>
-    <division>Bacteria</division>
-    <taxonomy>441771</taxonomy>
-    <db_name>clostridium_botulinum_a_str_hall</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Clostridium difficile 630</name>
-    <division>Bacteria</division>
-    <taxonomy>272563</taxonomy>
-    <db_name>clostridium_difficile_630</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Chlorobium tepidum TLS</name>
-    <division>Bacteria</division>
-    <taxonomy>194439</taxonomy>
-    <db_name>chlorobium_tepidum_tls</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Chloroflexus aurantiacus J-10-fl</name>
-    <division>Bacteria</division>
-    <taxonomy>324602</taxonomy>
-    <db_name>chloroflexus_aurantiacus_j_10_fl</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Citrobacter freundii 4_7_47CFAA</name>
-    <division>Bacteria</division>
-    <taxonomy>742730</taxonomy>
-    <db_name>citrobacter_freundii_4_7_47cfaa</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Chlamydia trachomatis D/UW-3/CX</name>
-    <division>Bacteria</division>
-    <taxonomy>272561</taxonomy>
-    <db_name>chlamydia_trachomatis_d_uw_3_cx</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Caulobacter crescentus CB15</name>
-    <division>Bacteria</division>
-    <taxonomy>190650</taxonomy>
-    <db_name>caulobacter_crescentus_cb15</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Cenarchaeum symbiosum A</name>
-    <division>Bacteria</division>
-    <taxonomy>414004</taxonomy>
-    <db_name>cenarchaeum_symbiosum_a</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Candidatus Korarchaeum cryptofilum OPF8</name>
-    <division>Bacteria</division>
-    <taxonomy>374847</taxonomy>
-    <db_name>candidatus_korarchaeum_cryptofilum_opf8</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Candidatus Koribacter versatilis Ellin345</name>
-    <division>Bacteria</division>
-    <taxonomy>204669</taxonomy>
-    <db_name>candidatus_koribacter_versatilis_ellin345</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Campylobacter jejuni subsp. jejuni NCTC 11168 = ATCC 700819</name>
-    <division>Bacteria</division>
-    <taxonomy>192222</taxonomy>
-    <db_name>campylobacter_jejuni_subsp_jejuni_nctc_11168_atcc_700819</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Burkholderia pseudomallei 1710b</name>
-    <division>Bacteria</division>
-    <taxonomy>320372</taxonomy>
-    <db_name>burkholderia_pseudomallei_1710b</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Buchnera aphidicola str. APS (Acyrthosiphon pisum)</name>
-    <division>Bacteria</division>
-    <taxonomy>107806</taxonomy>
-    <db_name>buchnera_aphidicola_str_aps_acyrthosiphon_pisum_</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Brucella abortus bv. 1 str. 9-941</name>
-    <division>Bacteria</division>
-    <taxonomy>262698</taxonomy>
-    <db_name>brucella_abortus_bv_1_str_9_941</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Bordetella pertussis Tohama I</name>
-    <division>Bacteria</division>
-    <taxonomy>257313</taxonomy>
-    <db_name>bordetella_pertussis_tohama_i</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Borrelia burgdorferi B31</name>
-    <division>Bacteria</division>
-    <taxonomy>224326</taxonomy>
-    <db_name>borrelia_burgdorferi_b31</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Bifidobacterium longum NCC2705</name>
-    <division>Bacteria</division>
-    <taxonomy>206672</taxonomy>
-    <db_name>bifidobacterium_longum_ncc2705</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Bacteroides thetaiotaomicron VPI-5482</name>
-    <division>Bacteria</division>
-    <taxonomy>226186</taxonomy>
-    <db_name>bacteroides_thetaiotaomicron_vpi_5482</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Bartonella henselae str. Houston-1</name>
-    <division>Bacteria</division>
-    <taxonomy>283166</taxonomy>
-    <db_name>bartonella_henselae_str_houston_1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Bacillus subtilis subsp. subtilis str. 168</name>
-    <division>Bacteria</division>
-    <taxonomy>224308</taxonomy>
-    <db_name>bacillus_subtilis_subsp_subtilis_str_168</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Azotobacter vinelandii DJ</name>
-    <division>Bacteria</division>
-    <taxonomy>322710</taxonomy>
-    <db_name>azotobacter_vinelandii_dj</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Anaplasma phagocytophilum HZ</name>
-    <division>Bacteria</division>
-    <taxonomy>212042</taxonomy>
-    <db_name>anaplasma_phagocytophilum_hz</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Aquifex aeolicus VF5</name>
-    <division>Bacteria</division>
-    <taxonomy>224324</taxonomy>
-    <db_name>aquifex_aeolicus_vf5</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Archaeoglobus fulgidus DSM 4304</name>
-    <division>Bacteria</division>
-    <taxonomy>224325</taxonomy>
-    <db_name>archaeoglobus_fulgidus_dsm_4304</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Agrobacterium fabrum str. C58</name>
-    <division>Bacteria</division>
-    <taxonomy>176299</taxonomy>
-    <db_name>agrobacterium_fabrum_str_c58</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Aeromonas hydrophila subsp. hydrophila ATCC 7966</name>
-    <division>Bacteria</division>
-    <taxonomy>380703</taxonomy>
-    <db_name>aeromonas_hydrophila_subsp_hydrophila_atcc_7966</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Aeropyrum pernix K1</name>
-    <division>Bacteria</division>
-    <taxonomy>272557</taxonomy>
-    <db_name>aeropyrum_pernix_k1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Aggregatibacter actinomycetemcomitans D11S-1</name>
-    <division>Bacteria</division>
-    <taxonomy>668336</taxonomy>
-    <db_name>aggregatibacter_actinomycetemcomitans_d11s_1</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Actinobacillus pleuropneumoniae serovar 5b str. L20</name>
-    <division>Bacteria</division>
-    <taxonomy>416269</taxonomy>
-    <db_name>actinobacillus_pleuropneumoniae_serovar_5b_str_l20</db_name>
-    <Published>Yes</Published>
-  </node>
-  <node>
-    <name>Acinetobacter baumannii AYE</name>
-    <division>Bacteria</division>
-    <taxonomy>509173</taxonomy>
-    <db_name>acinetobacter_baumannii_aye</db_name>
-    <Published>Yes</Published>
-  </node>
+</nodes>
 </nodes>


### PR DESCRIPTION
This PR would update the Pan Compara species files `pan_compara_species.html` and `pan_compara_species.xml` for eg63/e116.

Examples:
- [pan_compara_species.html](http://wp-np2-35.ebi.ac.uk:5098/ssi/species/pan_compara_species.html)
- [pan_compara_species.xml](http://wp-np2-35.ebi.ac.uk:5098/ssi/species/pan_compara_species.xml)