### PR TITLE
Change space to underscore in homoeology export file names

### DIFF
--- a/modules/EnsEMBL/Web/Component/DataExport/Homoeologs.pm
+++ b/modules/EnsEMBL/Web/Component/DataExport/Homoeologs.pm
@@ -79,7 +79,7 @@ sub content {
 
 sub default_file_name {
   my $self = shift;
-  my $name = $self->hub->species_defs->SPECIES_DISPLAY_NAME;
+  (my $name = $self->hub->species_defs->SPECIES_DISPLAY_NAME) =~ s/ /_/g;
 
   $name .= '_'.$self->hub->param('gene_name').'_homoeologues';
   return $name;


### PR DESCRIPTION
This PR would change homoeologue export file names to replace spaces with low lines, in line with handling of export file names for [homologies](https://github.com/Ensembl/ensembl-webcode/blob/2edf31774476273d79e3c63e6aeafb2f3ac629c9/modules/EnsEMBL/Web/Component/DataExport/Homologs.pm#L63), [orthologies](https://github.com/Ensembl/ensembl-webcode/blob/2edf31774476273d79e3c63e6aeafb2f3ac629c9/modules/EnsEMBL/Web/Component/DataExport/Orthologs.pm#L92) and [paralogies](https://github.com/Ensembl/ensembl-webcode/blob/2edf31774476273d79e3c63e6aeafb2f3ac629c9/modules/EnsEMBL/Web/Component/DataExport/Paralogs.pm#L82).
