### PR TITLE
Deactivate strain menu items for genes without strain tree

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Gene.pm
+++ b/modules/EnsEMBL/Web/Configuration/Gene.pm
@@ -110,7 +110,7 @@ sub modify_tree {
               paralogues EnsEMBL::Web::Component::Gene::ComparaHomoeologs
               )
           ],
-          {'availability' => 'gene database:compara core has_strain_homoeologs', 'concise' => 'Homoeologues'}
+          {'availability' => 'gene database:compara core has_strain_gene_tree has_strain_homoeologs', 'concise' => 'Homoeologues'}
         ),
         $self->create_node(
           'Strain_Compara_Homoeolog/Alignment',
@@ -120,7 +120,7 @@ sub modify_tree {
               alignment EnsEMBL::Web::Component::Gene::HomologAlignment
               )
           ],
-          {'availability' => 'gene database:compara core has_strain_homoeologs', 'no_menu_entry' => 1}
+          {'availability' => 'gene database:compara core has_strain_gene_tree has_strain_homoeologs', 'no_menu_entry' => 1}
         )
       );
     }


### PR DESCRIPTION
In conjunction with an ensembl-webcode PR, this pull request would deactivate strain-level homology menu items for genes lacking a strain-level gene tree.

A gene can have inferred strain homologies even if it lacks an inferred gene tree within the strain dataset. For example, if a strain gene-trees pipeline assigns a gene to a cluster containing only genes that are in the default collection, the cluster may be deleted from the strain gene-tree dataset, though homologies may have been inferred between its gene members in the default gene-trees pipeline.

In these cases, the homologies may be available through both the default and strain-level menu items. As the strain-level homology view is redundant with the default homology view, deactivating its menu item will not necessarily negatively impact the accessibility of the relevant homology data.