### PR TITLE
Remove dynamic TreeFam link code

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -156,7 +156,6 @@ SPBASE = http://www.spbase.org/SpBase/search/viewAnnoGeneInfo.php?spu_id=###ID##
 # we dont want these three links in EG
 PHYLOMEDB                   =
 GENOMICUSSYNTENY =
-TREEFAMSEQ =
 
 EST_EXONERATE = http://www.ebi.ac.uk/ena/data/view/###ID###
 ENA_FEATURE = https://www.ebi.ac.uk/ena/browser/view/###ID###
@@ -358,7 +357,6 @@ STRING                      = http://version_10.string-db.org/cgi/network.pl?all
 SUPERFAMILY                 = http://supfam.org/SUPERFAMILY/cgi-bin/scop.cgi?ipid=###ID###
 TCAG                        =
 TIFFIN                      =
-;TREEFAM                     = http://www.treefam.org/cgi-bin/TFseq.pl?id=###ID###
 UNIGENE                     = http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?db=unigene&term=###ID###
 UNIPROT/SPTREMBL            = http://www.uniprot.org/uniparc/?query=###ID###&sort=score
 UNIPROT/SWISSPROT           = http://www.uniprot.org/uniparc/?query=###ID###&sort=score
@@ -597,7 +595,6 @@ INTERPRO                    = http://www.ebi.ac.uk/interpro/entry/###ID###
 REFSEQ_DNA                  = http://www.ncbi.nlm.nih.gov/sites/entrez?db=nuccore&cmd=search&term=###ID###
 REFSEQ_PEPTIDE              = http://www.ncbi.nlm.nih.gov/sites/entrez?db=protein&cmd=search&term=###ID###
 REFSEQ_RNA                  = http://www.ncbi.nlm.nih.gov/sites/entrez?db=nuccore&cmd=search&term=###ID###
-;TREEFAM                     = http://www.treefam.org/cgi-bin/TFseq.pl?id=###ID###
 ;PHYLOMEDB                   = http://phylomedb.bioinfo.cipf.es/index.html?Hsapiens001&###ID###
 ;UNIPROT/SPTREMBL            = http://www.uniprot.org/uniparc/?query=###ID###&sort=score
 ;UNIPROT/SWISSPROT           = http://www.uniprot.org/uniparc/?query=###ID###&sort=score

--- a/modules/EnsEMBL/Web/ZMenu/Gene/ComparaTree.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Gene/ComparaTree.pm
@@ -29,7 +29,6 @@ sub content {
   my $species_path = $hub->species_path($species);
   my $phy_link     = $hub->get_ExtURL('PHYLOMEDB', $stable_id);
   my $dyo_link     = $hub->get_ExtURL('GENOMICUSSYNTENY', $stable_id);
-  my $treefam_link = $hub->get_ExtURL('TREEFAMSEQ', $stable_id);
   my $ens_tran     = $object->Obj->canonical_transcript; # Link to protein sequence for cannonical or longest translation
   my $ens_prot;
   
@@ -104,17 +103,6 @@ sub content {
       position => 17
     });
   }
-  
-  if ($treefam_link) {
-    $self->add_entry({
-      type     => 'TreeFam',
-      label    => 'Gene in TreeFam',
-      link     => $treefam_link,
-      external => 1,
-      position => 18
-    });
-  }
-  
 }
 
 1;


### PR DESCRIPTION
In parallel with [ensembl-webcode PR 1148](https://github.com/Ensembl/ensembl-webcode/pull/1148), this pull request would remove dynamic TreeFam link code and config.