### PR TITLE
Update gene families docs and reforge AllBio links

### DIFF
--- a/htdocs/info/about/collaborations/allbio.html
+++ b/htdocs/info/about/collaborations/allbio.html
@@ -8,10 +8,10 @@
 
 <p><a href="http://www.allbioinformatics.eu/doku.php">
 <img src="/img/allbio.png" alt="AllBio logo" style="width:200px;height:134px" class="float-left"></a>
-<a href="http://cordis.europa.eu/fp7/home_en.html">
+<a href="https://cordis.europa.eu/programme/id/FP7">
 <img src="/img/credits/eu_flag_small.jpg" alt="EU flag" style="width:147px;height:100px" class="float-right"></a>
 <a href="http://www.allbioinformatics.eu/doku.php">AllBio</a> is an 
-<a href="http://cordis.europa.eu/fp7/home_en.html">EU Framework 7</a> project that is 
+<a href="https://cordis.europa.eu/programme/id/FP7">EU Framework 7</a> project that is
 coordinating efforts to make human genome related technologies additionally work in 
 fields like microbial, plant, and lifestock bioinformatics. AllBio provides support 
 for training at the EBI for Ensembl Genomes and other related topics.</p>

--- a/htdocs/info/genome/compara/family_compara.html
+++ b/htdocs/info/genome/compara/family_compara.html
@@ -9,14 +9,14 @@
 <h1>Gene families</h1>
 
 <p>Gene families are sets of proteins that have been clustered based on sequence similarity. 
-In Ensembl Genomes, these are used to provide a way of exploring similar proteins across a 
-wide range of bacterial genomes for which the standard peptide comparative pipeline cannot be run. 
-Gene families are displayed in the <a
+They are displayed in the <a
   href="https://bacteria.ensembl.org/Escherichia_coli_str_k_12_substr_mg1655_gca_000005845/Gene/Gene_families?g=b0344;r=Chromosome:362455-365529;t=AAC73447">
   web interface</a>
 or can be accessed using the <a href="/info/docs/api/compara/compara_tutorial.html">Ensembl Compara Perl API</a>.</p>
 
-<p>In Ensembl Bacteria, Fungi and Protists, gene families are populated with proteins on all genomes by using
+<p>In Ensembl Bacteria, Fungi and Protists, gene families provide a way of exploring similar proteins
+across a wide range of bacterial genomes for which the standard peptide comparative pipeline cannot be run.
+They are populated with proteins on all genomes by using
 the <a href="https://hamap.expasy.org/">HAMAP</a> and <a href="https://www.pantherdb.org/">PANTHER</a>
 classification provided by <a href="https://www.ebi.ac.uk/interpro">InterPro</a>. This InterPro gene families
 pipeline uses the same database schema and API as the <a href="https://www.ensembl.org/info/genome/compara/family.html">


### PR DESCRIPTION
This PR would:
- update gene families documentation: [sandbox](http://wp-np2-35.ebi.ac.uk:5091/info/genome/compara/family_compara.html) vs [staging](https://staging-fungi.ensembl.org/info/genome/compara/family_compara.html)
- reforge FP7 links in the AllBio collaboration page: [sandbox](http://wp-np2-35.ebi.ac.uk:5091/info/about/collaborations/allbio.html) vs [staging](https://staging-fungi.ensembl.org/info/about/collaborations/allbio.html)