### PR TITLE
Adopt webcode fixes of Compara code

### DIFF
--- a/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
+++ b/modules/EnsEMBL/Web/Component/Location/Compara_AlignSliceBottom.pm
@@ -131,6 +131,7 @@ sub content {
   my ($alert_box, $error) = $self->check_for_align_problems({
                                 'align'   => $align, 
                                 'species' => $prodname, 
+                                'ignore'  => 'ancestral_sequences',
                                 'image'   => $self->has_image,
                                 'cdb'     => $self->param('cdb') || 'compara',
                                 });

--- a/modules/EnsEMBL/Web/ZMenu/Contig.pm
+++ b/modules/EnsEMBL/Web/ZMenu/Contig.pm
@@ -51,7 +51,8 @@ sub content {
     link  => $hub->url({ 
       type   => 'Location', 
       action => $action, 
-      region => $slice_name 
+      region => $slice_name,
+      r => sprintf '%s:%s-%s', map $top_level_slice->$_, qw(seq_region_name start end)
     })
   }) unless $no_center_on_contig;
   
@@ -137,7 +138,8 @@ sub content {
       link  => $hub->url({
         type   => 'Location', 
         action => $action, 
-        region => $new_slice_name
+        region => $new_slice_name,
+        r => sprintf '%s:%s-%s', map $new_slice->$_, qw(seq_region_name start end)
       })
     });
 


### PR DESCRIPTION
This PR would adopt in `eg-web-common` two fixes previously implemented in `ensembl-webcode`:

## Ignore ancestral sequences in alignment problem check
Implemented by @ens-ap5 in [ensembl-webcode commit 1fb6356](https://github.com/Ensembl/ensembl-webcode/commit/1fb6356)

Example in Plants:
- Oryza sativa region 2:1-400 on [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Oryza_sativa/Location/Compara_Alignments/Image?r=2:1-400;db=core;align=9910) and [staging](https://staging-plants.ensembl.org/Oryza_sativa/Location/Compara_Alignments/Image?db=core;r=2:1-400;align=9910)

## Fix jump to region in NV AlignSlice views
Implemented by @jyothishnt in [ensembl-webcode commit f62be03](https://github.com/Ensembl/ensembl-webcode/commit/f62be03)

When in an image alignment view, click on any contig element, and in the Zmenu, click on the "Centre on ..." link.

Example in Metazoa:
- Apis mellifera region CM009944.2:6529304-6531367 on [sandbox](http://wp-np2-35.ebi.ac.uk:5094/Apis_mellifera/Location/Compara_Alignments/Image?r=CM009944.2:6529304-6531367;align=9778;db=core) and [staging](https://staging-metazoa.ensembl.org/Apis_mellifera/Location/Compara_Alignments/Image?r=CM009944.2:6529304-6531367;align=9778;db=core)

Example in Vertebrates:
- Mouse region 4:136366473-136547301 on [staging site](https://staging.ensembl.org/Mus_musculus/Location/Compara_Alignments/Image?align=9560&db=core&r=4%3A136366473-136547301)