### PR TITLE
Set EGB_NCBI config to GDV

### DIFF
--- a/conf/ini-files/DEFAULTS.ini
+++ b/conf/ini-files/DEFAULTS.ini
@@ -395,7 +395,7 @@ EC                       = http://www.expasy.ch/cgi-bin/nicezyme.pl?###ID###
 EC_PATHWAY               = http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[ENZYME:###ID###]
 EGB_TEST                 = javascript:window.alert('Chr###CHR###:###START###-###END###');
 EGB_UCSC                 = http://genome.ucsc.edu/cgi-bin/hgTracks?db=###UCSC_DB###&position=Chr###CHR###:###START###-###END###
-EGB_NCBI                 = http://www.ncbi.nlm.nih.gov/mapview/maps.cgi?taxid=###NCBI_DB###&CHR=###CHR###&BEG=###START###&END=###END###
+EGB_NCBI                 = https://www.ncbi.nlm.nih.gov/genome/gdv/browser/?context=genome&acc=###ACCESSION###&chr=###CHR###&from=###START###&to=###END###
 
 EMBL_HOME                = http://www.ebi.ac.uk/
 


### PR DESCRIPTION
This PR would set the `EGB_NCBI` config to point to the [NCBI Genome Data Viewer](https://www.ncbi.nlm.nih.gov/gdv/) (GDV) instead of the [retired NCBI Map Viewer service](https://ncbiinsights.ncbi.nlm.nih.gov/2018/04/25/ncbi-retires-map-viewer-web-interface/).

The table below shows info pages of the 3 affected species, all in Ensembl Metazoa.

For each species, the `sandbox_page` and `rc_page` columns contain links to relevant pages in the sandbox and RC sites, respectively. The `genbank_accession` contains the GenBank accession of the assembly as shown in Ensembl, while the `resolved_refseq_accession` shows the RefSeq accession resolved by the GDV when accessed via the Ensembl  link for "Other genome browsers". The `accession_correspondence` shows the result of an initial check of the correspondence between the GenBank accession and resolved RefSeq accession.

| sandbox_page | rc_page | genbank_accession | resolved_refseq_accession | accession_correspondence
|--------------|---------|-------------------|---------------------------|-
| [Anopheles_gambiae](http://wp-np2-35.ebi.ac.uk:5094/Anopheles_gambiae/Location/Genome) | [Anopheles_gambiae](https://rc-metazoa.ensembl.org/Anopheles_gambiae/Location/Genome/Location/Genome) | GCA_000005575.1 | GCF_000005575.2 | `ok`
| [Caenorhabditis_elegans](http://wp-np2-35.ebi.ac.uk:5094/Caenorhabditis_elegans/Location/Genome) | [Caenorhabditis_elegans](https://rc-metazoa.ensembl.org/Caenorhabditis_elegans/Location/Genome/Location/Genome) | GCA_000002985.3 | GCF_000002985.6 | `ok`
| [Drosophila_melanogaster](http://wp-np2-35.ebi.ac.uk:5094/Drosophila_melanogaster/Location/Genome) | [Drosophila_melanogaster](https://rc-metazoa.ensembl.org/Drosophila_melanogaster/Location/Genome/Location/Genome) | GCA_000001215.4 | GCF_000001215.4 | `ok`

This PR may be of interest to @vsitnik.