### PR TITLE
Tweak handling of gene family data

### DIFF
--- a/modules/EnsEMBL/Web/Component/Gene/GeneFamilySeq.pm
+++ b/modules/EnsEMBL/Web/Component/Gene/GeneFamilySeq.pm
@@ -44,22 +44,16 @@ sub content {
   my $compara_db       = $object->database('compara');
   my $family_adaptor   = $compara_db->get_FamilyAdaptor;
   my $family           = $family_adaptor->fetch_by_stable_id($gene_family_id);
-  my @all_members      = @{ $family->get_all_Members };
-  my $filtered_data    = $object->filtered_family_data($family);
-  my %filtered_members = map {$_->{species} . '|' . $_->{id} => $_} @{$filtered_data->{members}};
+  my $filtered_data    = $object->filtered_family_data($family, 1);
   my $html = '';
 
   my $lookup = $species_defs->prodnames_to_urls_lookup;
-  foreach my $member (@all_members) {
-    my $member_id   = $member->stable_id;
-    my $member_key  = $member->genome_db->name . '|' . $member_id;
-    my $member_data = $filtered_members{$member_key};
-    next unless $member_data;
+  foreach my $member_data (@{$filtered_data->{members}}) {
 
-    my $sequence = $member->sequence;
+    my $sequence = $member_data->{sequence};
     next unless $sequence;
 
-    my $title = join ' ', $member_id, $member_data->{description}, '('.$species_defs->species_label($lookup->{$member_data->{species}}).')';
+    my $title = join ' ', $member_data->{id}, $member_data->{description}, '('.$species_defs->species_label($lookup->{$member_data->{species}}).')';
     $title   .= " (gene=$member_data->{name})" if $member_data->{name};
 
     if($format =~ /^text$/i){

--- a/modules/EnsEMBL/Web/Object/Gene.pm
+++ b/modules/EnsEMBL/Web/Object/Gene.pm
@@ -185,7 +185,7 @@ sub get_go_list {
 }
 
 sub filtered_family_data {
-  my ($self, $family) = @_;
+  my ($self, $family, $include_sequences) = @_;
   my $hub       = $self->hub;
   my $family_id = $family->stable_id;
   
@@ -197,29 +197,35 @@ sub filtered_family_data {
   } 
 
   if(!@$members) {
-    my $member_objs = $family->get_all_Members;
 
-    # API too slow, use raw SQL to get stable_id, name and desc for all genes
-    my $gene_info = $self->database('compara')->dbc->db_handle->selectall_hashref(
-      'SELECT g.gene_member_id, g.stable_id, g.display_label, g.description FROM family f
+    # API too slow, use raw SQL to get the data we need
+    my $gene_rows = $self->database('compara')->dbc->db_handle->selectall_arrayref(
+      'SELECT
+           g.display_label,
+           g.stable_id,
+           s.stable_id,
+           s.taxon_id,
+           g.description,
+           gdb.name
+       FROM family f
        JOIN family_member fm USING (family_id) 
        JOIN seq_member s USING (seq_member_id) 
+       JOIN genome_db gdb USING (genome_db_id)
        JOIN gene_member g USING (gene_member_id) 
        WHERE f.stable_id = ?',
-      'gene_member_id',
       undef,
       $family_id
     );
 
-    foreach my $member (@$member_objs) {
-      my $gene = $gene_info->{$member->gene_member_id};
+    foreach my $row ( @$gene_rows ) {
+      my ($gene_name, $gene_stable_id, $member_stable_id, $taxon_id, $gene_description, $genome_db_name) = @$row;
       push (@$members, {
-        name        => $gene->{display_label},
-        gene_id     => $gene->{stable_id},
-        id          => $member->stable_id,
-        taxon_id    => $member->taxon_id,
-        description => $gene->{description},
-        species     => $member->genome_db->name
+        name        => $gene_name,
+        gene_id     => $gene_stable_id,
+        id          => $member_stable_id,
+        taxon_id    => $taxon_id,
+        description => $gene_description,
+        species     => $genome_db_name,
       });  
     }
 
@@ -231,6 +237,29 @@ sub filtered_family_data {
     $temp_file->print($hub->jsonify($members));
     
   }  
+
+  if ($include_sequences) {
+
+    # A majority of gene families have at least some redundant sequences, so we fetch
+    # sequences by their member stable_id, then match each sequence to its associated members.
+    my $seq_recs = $self->database('compara')->dbc->db_handle->selectall_hashref(
+      'SELECT s.stable_id AS member_stable_id, sequence
+       FROM family f
+       JOIN family_member fm USING (family_id)
+       JOIN seq_member s USING (seq_member_id)
+       JOIN sequence USING (sequence_id)
+       WHERE f.stable_id = ?',
+       'member_stable_id',
+       undef,
+       $family_id
+    );
+
+    foreach my $member (@$members) {
+      my $member_stable_id = $member->{id};
+      my $seq_rec = $seq_recs->{$member_stable_id};
+      $member->{sequence} = $seq_rec->{sequence};
+    }
+  }
   
   my $total_member_count  = scalar @$members;
      


### PR DESCRIPTION
Gene family views can take some time to load, particularly for large families.

This pull request would make some adjustments to handling of family data, with the aim of reducing access times.

In `EnsEMBL::Web::Object::Gene::filtered_family_data`, instead of combining a Compara Perl API call and MySQL query,
we would fetch all the standard family data with a single query.

In `EnsEMBL::Web::Component::Gene::GeneFamilySeq`, instead of combining data fetched via the Compara Perl API with the results of `EnsEMBL::Web::Object::Gene::filtered_family_data`, we would use a modified version of `filtered_family_data` which enables us to fetch the translation sequence alongside standard family data.

Examples:
- Oat cultivar Sang gene AVESA.00010b.r2.1AG0008120 on [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Avena_sativa_Sang/Gene/Gene_families?g=AVESA.00010b.r2.1AG0008120) and [live site](https://plants.ensembl.org/Avena_sativa_Sang/Gene/Gene_families?g=AVESA.00010b.r2.1AG0008120)
- Wheat cultivar Kariega gene TraesKAR1A01G0000500 on [sandbox](http://wp-np2-35.ebi.ac.uk:5098/Triticum_aestivum_kariega/Gene/Gene_families?db%3Dcore;g=TraesKAR1A01G0000500) and [live site](https://plants.ensembl.org/Triticum_aestivum_kariega/Gene/Gene_families?db%3Dcore;g=TraesKAR1A01G0000500)
