### PR TITLE
Obtain alignment metadata via multi packed file

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -23,12 +23,20 @@ no warnings qw(uninitialized);
 
 use LWP::UserAgent;
 
-use previous qw(munge_config_tree);
+use EnsEMBL::Web::Utils::Compara;
+
+use previous qw(munge_config_tree munge_databases_multi);
 
 sub munge_config_tree {
   my $self = shift;
   $self->PREV::munge_config_tree(@_);
   $self->_configure_external_resources;
+}
+
+sub munge_databases_multi {
+  my $self = shift;
+  $self->PREV::munge_databases_multi(@_);
+  $self->_summarise_eg_alignment_metadata;
 }
 
 sub _intraspecies_sql {
@@ -124,6 +132,14 @@ sub _configure_external_resources {
       }
     }
   }
+}
+
+sub _summarise_eg_alignment_metadata {
+  my $self = shift;
+  my $db_name = 'DATABASE_COMPARA';
+  my $dbh = $self->db_connect($db_name);
+  $self->db_tree->{$db_name}{'EG_ALIGNMENT_METADATA'} = EnsEMBL::Web::Utils::Compara::_query_compara_alignments($dbh);
+  $dbh->disconnect;
 }
 
 1;

--- a/modules/EnsEMBL/Web/Document/HTML/Compara.pm
+++ b/modules/EnsEMBL/Web/Document/HTML/Compara.pm
@@ -25,6 +25,7 @@ use strict;
 
 use Math::Round;
 use EnsEMBL::Web::Document::Table;
+use EnsEMBL::Web::Utils::Compara;
 use Bio::EnsEMBL::Compara::Method;
 use Bio::EnsEMBL::Compara::Utils::SpeciesTree;
 use Data::Dumper;
@@ -148,8 +149,7 @@ sub table {
   my ($self, $species) = @_;
     
   my $hub  = $self->hub;
-  my $methods = ['SYNTENY', 'TRANSLATED_BLAT_NET','BLASTZ_NET', 'LASTZ_NET', 'POLYPLOID', 'CACTUS_HAL_PW', 'ATAC'];
-  my $data = get_compara_alignments($hub->database('compara'), $methods);
+  my $data = $hub->species_defs->multi_hash->{'DATABASE_COMPARA'}{'EG_ALIGNMENT_METADATA'} // {};
 
   my $thtml = qq{<table id="genomic_align_table" class="no_col_toggle ss autocenter" style="width: 100%" cellpadding="0" cellspacing="0">};
 
@@ -275,47 +275,7 @@ sub get_compara_alignments {
   
  my $dbh = $compara_db->dbc->db_handle;
  
- my $rows = $dbh->selectall_arrayref(
-          "SELECT ml.type,
-                  gd1.name AS gd1_name,
-                  gd2.name AS gd2_name,
-                  mlss.method_link_species_set_id,
-                  mlsst_blocks.value AS num_blocks
-           FROM method_link ml
-                JOIN method_link_species_set mlss
-                  USING (method_link_id)
-                JOIN species_set_header ssh
-                  USING (species_set_id)
-                JOIN species_set ss1
-                  ON ss1.species_set_id = ssh.species_set_id
-                JOIN genome_db gd1
-                  ON gd1.genome_db_id = ss1.genome_db_id
-                JOIN species_set ss2
-                  ON ss2.species_set_id = ssh.species_set_id
-                JOIN genome_db gd2
-                  ON gd2.genome_db_id = ss2.genome_db_id
-                LEFT JOIN method_link_species_set_tag mlsst_blocks
-                  ON mlsst_blocks.method_link_species_set_id = mlss.method_link_species_set_id
-                  AND mlsst_blocks.tag = 'num_blocks'
-           WHERE 
-                ml.type IN ('SYNTENY', 'TRANSLATED_BLAT_NET', 'BLASTZ_NET', 'LASTZ_NET', 'POLYPLOID', 'CACTUS_HAL_PW', 'ATAC')
-                AND (ssh.size = 1 OR gd1.genome_db_id < gd2.genome_db_id)
-                ORDER BY gd1.name, gd2.name", { Slice => {} }
-        ); 
-        
-        
-        my $data = {};
-        
-        if(scalar(@$rows)){
-            foreach my $row (@$rows){
-                $data->{$row->{'gd1_name'}}->{align}->{$row->{'gd2_name'}}->{$row->{'type'}} = [$row->{'method_link_species_set_id'},  $row->{'num_blocks'} ? 1 : 0];
-                if($row->{'gd2_name'} ne $row->{'gd1_name'}){
-                    $data->{$row->{'gd2_name'}}->{align}->{$row->{'gd1_name'}}->{$row->{'type'}} = [$row->{'method_link_species_set_id'},  $row->{'num_blocks'} ? 1 : 0];
-                }
-            }
-         }
-            
-  return $data;
+  return EnsEMBL::Web::Utils::Compara::_query_compara_alignments($dbh);
 }
 
 1;

--- a/modules/EnsEMBL/Web/Utils/Compara.pm
+++ b/modules/EnsEMBL/Web/Utils/Compara.pm
@@ -1,0 +1,71 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2025] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Utils::Compara;
+
+use strict;
+
+
+sub _query_compara_alignments {
+  my ($dbh) = @_;
+
+  my $rows = $dbh->selectall_arrayref("
+    SELECT ml.type,
+           gd1.name AS gd1_name,
+           gd2.name AS gd2_name,
+           mlss.method_link_species_set_id,
+           mlsst_blocks.value AS num_blocks
+    FROM method_link ml
+         JOIN method_link_species_set mlss
+           USING (method_link_id)
+         JOIN species_set_header ssh
+           USING (species_set_id)
+         JOIN species_set ss1
+           ON ss1.species_set_id = ssh.species_set_id
+         JOIN genome_db gd1
+           ON gd1.genome_db_id = ss1.genome_db_id
+         JOIN species_set ss2
+           ON ss2.species_set_id = ssh.species_set_id
+         JOIN genome_db gd2
+           ON gd2.genome_db_id = ss2.genome_db_id
+         LEFT JOIN method_link_species_set_tag mlsst_blocks
+           ON mlsst_blocks.method_link_species_set_id = mlss.method_link_species_set_id
+           AND mlsst_blocks.tag = 'num_blocks'
+         WHERE
+           ml.type IN ('SYNTENY', 'TRANSLATED_BLAT_NET', 'BLASTZ_NET', 'LASTZ_NET', 'POLYPLOID', 'CACTUS_HAL_PW', 'ATAC')
+           AND (ssh.size = 1 OR gd1.genome_db_id < gd2.genome_db_id)
+           ORDER BY gd1.name, gd2.name
+  ", { Slice => {} });
+
+  my $data = {};
+
+  if(scalar(@$rows)){
+    foreach my $row (@$rows){
+      $data->{$row->{'gd1_name'}}->{align}->{$row->{'gd2_name'}}->{$row->{'type'}} = [$row->{'method_link_species_set_id'},  $row->{'num_blocks'} ? 1 : 0];
+      if($row->{'gd2_name'} ne $row->{'gd1_name'}){
+        $data->{$row->{'gd2_name'}}->{align}->{$row->{'gd1_name'}}->{$row->{'type'}} = [$row->{'method_link_species_set_id'},  $row->{'num_blocks'} ? 1 : 0];
+      }
+    }
+  }
+
+  return $data;
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR would refactor the database query in `EnsEMBL::Web::Document::HTML::Compara::get_compara_alignments` to a new function, `EnsEMBL::Web::Utils::Compara::_query_compara_alignments`.

The new function would be called by a new `EnsEMBL::Web::ConfigPacker::_summarise_eg_alignment_metadata` method as well as the existing `get_compara_alignments` function.

The new `ConfigPacker` method would pack Compara alignment metadata into an `EG_ALIGNMENT_METADATA` data structure, which would in turn be used in `EnsEMBL::Web::Document::HTML::Compara::table` in place of the database query currently being used.

## Views affected

This will change how alignment information is fetched for the Non-Vertebrates pairwise genomic alignments page.

Example: [sandbox](http://wp-np2-35.ebi.ac.uk:5098/info/genome/compara/compara_analyses.html) vs [live site](https://ensembl.org/info/genome/compara/compara_analyses.html)

## Possible complications

This change would require repacking of all Non-Vertebrate `MULTI.db.packed` files.

## Merge conflicts

None detected.

## Related JIRA Issues (EBI developers only)

- N/A
